### PR TITLE
Select interfaces for traffic monitoring

### DIFF
--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -363,3 +363,10 @@ class AsusRouterBridgeHTTP(AsusRouterBridge):
         return sensors
     ### <- GET SENSORS LIST
 
+
+    async def async_get_network_interfaces(self):
+        """"""
+
+        return await self._api.async_get_network_labels()
+
+

--- a/custom_components/asusrouter/compilers.py
+++ b/custom_components/asusrouter/compilers.py
@@ -1,0 +1,43 @@
+"""Compilers module for AsusRouter"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .dataclass import AsusRouterSensorDescription
+from .const import SENSORS_PARAM_NETWORK, KEY_SENSOR_ID
+
+KEY_SENSORS_NETWORK_STAT = "network_stat"
+
+
+def list_sensors_network(interfaces : list[str] | None = None) -> dict[str, Any]:
+    """Compile a list of network sensors"""
+
+    sensors = dict()
+
+    if not interfaces:
+        return sensors
+
+    for interface in interfaces:
+        for type in SENSORS_PARAM_NETWORK:
+            data = SENSORS_PARAM_NETWORK[type]
+            key = KEY_SENSOR_ID.format(interface, type)
+            sensors.update({
+                (KEY_SENSORS_NETWORK_STAT, key): AsusRouterSensorDescription(
+                    key = key,
+                    key_group = KEY_SENSORS_NETWORK_STAT,
+                    name = data["name"].format(interface) or None,
+                    icon = data["icon"] or None,
+                    state_class = data["state_class"] or None,
+                    native_unit_of_measurement = data["native_unit_of_measurement"] or None,
+                    factor = data["factor"] or None,
+                    entity_registry_enabled_default = data["entity_registry_enabled_default"] or None,
+                    extra_state_attributes = {
+                        key: data["raw_attribute"] or None,
+                    }
+                )
+            })
+
+    return sensors
+
+

--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -1,5 +1,21 @@
 """ASUS Router component constants"""
 
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.const import (
+    DATA_GIGABYTES,
+    DATA_RATE_MEGABITS_PER_SECOND,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+
+
 DOMAIN = "asusrouter"
 DATA_ASUSROUTER = DOMAIN
 
@@ -8,6 +24,9 @@ CONF_CERT_PATH = "cert_path"
 CONF_CACHE_TIME = "cache_time"
 CONF_ENABLE_MONITOR = "enable_monitor"
 CONF_ENABLE_CONTROL = "enable_control"
+CONF_INTERFACES = "interfaces"
+
+CONF_REQ_RELOAD = [CONF_INTERFACES]
 
 DEFAULT_USERNAME = "admin"
 DEFAULT_PORT = 0
@@ -18,6 +37,7 @@ DEFAULT_VERIFY_SSL = True
 DEFAULT_CACHE_TIME = 5
 DEFAULT_ENABLE_MONITOR = True
 DEFAULT_ENABLE_CONTROL = False
+DELAULT_INTERFACES = ["WAN"]
 
 SENSORS_CPU = ["total", "core_1", "core_2", "core_3", "core_4", "core_5", "core_6", "core_7", "core_8"]
 
@@ -30,4 +50,61 @@ SENSORS_CONNECTED_DEVICES = ["number"]
 SENSORS_MISC = ["boottime"]
 
 SENSORS_CHANGE = ["change"]
+
+CONVERT_TO_MEGA = 1048576
+CONVERT_TO_GIGA = 1073741824
+
+KEY_SENSOR_ID = "{}_{}"
+
+SENSORS_PARAM : dict[str, dict[str, Any]] = {
+    "key": {},
+    "key_group": {},
+    "name": {},
+    "icon": {},
+    "state_class": {},
+    "native_unit_of_measurement": {},
+    "factor": {},
+    "entity_registry_enabled_default": {},
+    "extra_state_attributes": {},
+}
+
+SENSORS_PARAM_NETWORK : dict[str, dict[str, Any]] = {
+    "rx": {
+        "name": "{} Download",
+        "icon": "mdi:download-outline",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "native_unit_of_measurement": DATA_GIGABYTES,
+        "factor": CONVERT_TO_GIGA,
+        "entity_registry_enabled_default": True,
+        "raw_attribute": "bytes",
+    },
+    "tx": {
+        "name": "{} Upload",
+        "icon": "mdi:upload-outline",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "native_unit_of_measurement": DATA_GIGABYTES,
+        "factor": CONVERT_TO_GIGA,
+        "entity_registry_enabled_default": True,
+        "raw_attribute": "bytes",
+    },
+    "rx_speed": {
+        "name": "{} Download Speed",
+        "icon": "mdi:download-network-outline",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "native_unit_of_measurement": DATA_RATE_MEGABITS_PER_SECOND,
+        "factor": CONVERT_TO_MEGA,
+        "entity_registry_enabled_default": True,
+        "raw_attribute": "bits/s",
+    },
+    "tx_speed": {
+        "name": "{} Upload Speed",
+        "icon": "mdi:upload-network-outline",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "native_unit_of_measurement": DATA_RATE_MEGABITS_PER_SECOND,
+        "factor": CONVERT_TO_MEGA,
+        "entity_registry_enabled_default": True,
+        "raw_attribute": "bits/s",
+    },
+}
+
 

--- a/custom_components/asusrouter/dataclass.py
+++ b/custom_components/asusrouter/dataclass.py
@@ -1,0 +1,41 @@
+"""Dataclass module for AsusRouter"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from collections.abc import Callable, Mapping
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.helpers.entity import EntityCategory, DeviceInfo, EntityDescription, Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+
+@dataclass
+class AsusRouterEntityDescription(EntityDescription):
+    """"""
+
+    key_group: Callable[[dict], str] | None = None
+    value: Callable[[Any], Any] = lambda val: val
+    factor: int | None = None
+    precision: int = 3
+    extra_state_attributes: dict[str, AsusRouterAttributeDescription] | None = None
+
+
+@dataclass
+class AsusRouterSensorDescription(AsusRouterEntityDescription, SensorEntityDescription):
+    """Describe AsusRouter sensor"""
+
+
+@dataclass
+class AsusRouterAttributeDescription(AsusRouterEntityDescription, SensorEntityDescription):
+    """Describe AsusRouter attribute"""

--- a/custom_components/asusrouter/router.py
+++ b/custom_components/asusrouter/router.py
@@ -37,6 +37,7 @@ from homeassistant.util import dt as dt_util
 
 from .bridge import AsusRouterBridge
 from .const import (
+    CONF_REQ_RELOAD,
     CONF_USE_SSL,
     CONF_CERT_PATH,
     CONF_CACHE_TIME,
@@ -52,10 +53,6 @@ from .const import (
     SENSORS_CONNECTED_DEVICES,
     DOMAIN,
 )
-
-CONF_REQ_RELOAD = [
-    CONF_CACHE_TIME
-]
 
 KEY_COORDINATOR = "coordinator"
 KEY_SENSORS = "sensors"

--- a/custom_components/asusrouter/strings.json
+++ b/custom_components/asusrouter/strings.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "step": {
-            "user": {
+            "device": {
                 "description": "[%key:common::config_flow::description%]",
                 "data": {
                     "name": "[%key:common::config_flow::data::name%]",
@@ -14,6 +14,12 @@
                     "cert_path": "[%key:common::config_flow::data::cert_path%]",
                     "enable_monitor": "[%key:common::config_flow::data::enable_monitor%]",
                     "enable_control": "[%key:common::config_flow::data::enable_control%]"
+                }
+            },
+            "interfaces": {
+                "description": "Interfaces to monitor",
+                "data": {
+                    "interfaces": "Select network interfaces to monitor"
                 }
             }
         },
@@ -29,6 +35,7 @@
             "init": {
                 "title": "ASUS Router options",
                 "data": {
+                    "interfaces": "Select network interfaces to monitor",
                     "cache_device_time": "Caching time for device discovery",
                     "cache_time": "Data caching time"
                 }

--- a/custom_components/asusrouter/translations/en.json
+++ b/custom_components/asusrouter/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "step": {
-            "user": {
+            "device": {
                 "description": "Parameters to connect to the router",
                 "data": {
                     "name": "The name for device (blank to use device model)",
@@ -14,6 +14,12 @@
                     "cert_path": "Certificate path",
                     "enable_monitor": "Enable device monitoring",
                     "enable_control": "Enable device control"
+                }
+            },
+            "interfaces": {
+                "description": "Interfaces to monitor",
+                "data": {
+                    "interfaces": "Select netwirk interfaces to monitor"
                 }
             }
         },
@@ -29,6 +35,7 @@
             "init": {
                 "title": "ASUS Router options",
                 "data": {
+                    "interfaces": "Select network interfaces to monitor",
                     "cache_device_time": "Caching time for device discovery",
                     "cache_time": "Data caching time"
                 }


### PR DESCRIPTION
Add config flow for interface selection on installation. Add interface selection to integration options

All the selected interfaces will get 4 sensors: `INTERFACE_` + `rx`, `tx`, `rx_speed`, `tx_speed` enabled by default