### PR TITLE
Add `ZenWiFi AX Mini (XD4)` to the supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The list of supported devices includes (but is not limited to):
 - `RT-AX89X`
 - `RT-AX92U`
 - `ZenWiFi AX (XT8)`
+- `ZenWiFi AX Mini (XD4)`
 
 Non-Asus devices:
 - `Netgear R7000` (FW: **Merlin**)


### PR DESCRIPTION
Closes #117 