### PR TITLE
Fix wrong wireless entities names

### DIFF
--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -409,7 +409,7 @@ NAME_GWLAN = {}
 NAME_WLAN = {}
 for i in range(len(CONNECTION_LIST)):
     # WLAN
-    NAME_WLAN = f"Wireless {CONNECTION_LIST[i]}"
+    NAME_WLAN[i] = f"Wireless {CONNECTION_LIST[i]}"
     # Guest WLAN
     for j in NUMERIC_GWLAN:
         NAME_GWLAN[f"{i}.{j}"] = f"Guest {CONNECTION_LIST[i]} {j}"


### PR DESCRIPTION
Required after a bug in #346 