### PR TITLE
Fix sysinfo sensors

### DIFF
--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -556,14 +556,13 @@ class ARBridge:
         return sensors
 
     @staticmethod
-    def _process_sensors_sysinfo(raw: dict[str, Any]) -> list[str]:
+    def _process_sensors_sysinfo(raw: Optional[dict[str, Any]]) -> list[str]:
         """Process SysInfo sensors."""
 
-        sensors = []
-        for sensor_type in SENSORS_SYSINFO:
-            if sensor_type in raw:
-                sensors.append(sensor_type)
-        return sensors
+        if raw is None or not isinstance(raw, dict):
+            return []
+
+        return SENSORS_SYSINFO
 
     @staticmethod
     def _process_sensors_vpn(raw: dict[str, Any]) -> list[str]:

--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -217,7 +217,7 @@ LABEL_WLAN_5GHZ = "5 GHz"
 LABEL_WLAN_5GHZ2 = "5 GHz-2"
 LABEL_WLAN_6GHZ = "6 GHz"
 LABELS_LOAD_AVG = {
-    f"{sensor}": f"{LABEL_LOAD_AVG} ({sensor} min)" for sensor in ("1", "5", "15")
+    sensor: f"{LABEL_LOAD_AVG} ({sensor} min)" for sensor in ("1", "5", "15")
 }
 LABELS_TEMPERATURE = {
     "cpu": "Temperature CPU",


### PR DESCRIPTION
#641 should be fixed now. The issue was because stock FW returns `None` due to sysinfo sensors missing