### PR TITLE
Assign `default_name` to clients instead of `name`

### DIFF
--- a/custom_components/asusrouter/device_tracker.py
+++ b/custom_components/asusrouter/device_tracker.py
@@ -113,7 +113,7 @@ class ARDeviceEntity(ScannerEntity):
             identifiers={
                 (DOMAIN, mac_address),
             },
-            name=name,
+            default_name=name,
             via_device=(DOMAIN, self._router.mac),
         )
 


### PR DESCRIPTION
This should help against assigning devices to AR instead of their native integrations