### PR TITLE
Add DSL datarate_down/up entity in HA sensors

### DIFF
--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_MODE,
     CPU,
     DEFAULT_SENSORS,
+    DSL,
     FIRMWARE,
     GWLAN,
     LED,
@@ -190,7 +191,7 @@ class ARBridge:
                 SENSORS: await self._get_sensors_modern(AsusData.CPU),
                 METHOD: self._get_data_cpu,
             },
-            "dsl": {
+            DSL: {
                 SENSORS: await self._get_sensors_modern(AsusData.DSL),
                 METHOD: self._get_data_dsl,
             },

--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -190,6 +190,10 @@ class ARBridge:
                 SENSORS: await self._get_sensors_modern(AsusData.CPU),
                 METHOD: self._get_data_cpu,
             },
+            "dsl": {
+                SENSORS: await self._get_sensors_modern(AsusData.DSL),
+                METHOD: self._get_data_dsl,
+            },
             FIRMWARE: {
                 SENSORS: SENSORS_FIRMWARE,
                 METHOD: self._get_data_firmware,
@@ -317,6 +321,11 @@ class ARBridge:
         """Get CPU data from the device."""
 
         return await self._get_data(AsusData.CPU)
+    
+    async def _get_data_dsl(self) -> dict[str, Any]:
+        """Get DSL data from the device."""
+
+        return await self._get_data_modern(AsusData.DSL)
 
     async def _get_data_firmware(self) -> dict[str, Any]:
         """Get firmware data from the device."""

--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -93,6 +93,7 @@ CORE = "core"
 CPU = "cpu"
 DEVICES = "devices"
 DNS = "dns"
+DSL = "dsl"
 FIRMWARE = "firmware"
 FREE = "free"
 GWLAN = "gwlan"
@@ -265,6 +266,7 @@ MODE_MEDIA_BRIDGE = MODE_ACCESS_POINT.copy()
 MODE_ROUTER = MODE_ACCESS_POINT.copy()
 MODE_ROUTER.extend(
     [
+        DSL,
         GWLAN,
         "ovpn_client",
         "ovpn_server",
@@ -1081,6 +1083,31 @@ STATIC_SENSORS: list[AREntityDescription] = [
         entity_registry_enabled_default=False,
         extra_state_attributes={f"{num}_usage": f"core_{num}" for num in NUMERIC_CORES},
     ),
+    # DSL
+    ARSensorDescription(
+        key="datarate_up",
+        key_group=DSL,
+        name="DSL Datarate Up",
+        icon="mdi:upload-network-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DATA_RATE,
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND, 
+        suggested_display_precision=0,
+        entity_registry_enabled_default=True,
+    ),
+    ARSensorDescription(
+        key="datarate_down",
+        key_group=DSL,
+        name="DSL Datarate Down",
+        icon="mdi:download-network-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DATA_RATE,
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        suggested_display_precision=0,
+        entity_registry_enabled_default=True,
+    ),
     # Latest connected
     ARSensorDescription(
         key="latest_time",
@@ -1181,24 +1208,6 @@ STATIC_SENSORS: list[AREntityDescription] = [
             "xip": "xip",
             "xtype": "xip_type",
             "xmask": "xmask",
-        },
-    ),
-    # DSL
-    ARSensorDescription(
-        key="datarate",
-        key_group="dsl",
-        name="DSL",
-        icon=ICON_ROUTER,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.DATA_RATE,
-        native_unit_of_measurement=UnitOfDataRate.BITS_PER_SECOND,
-        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        extra_state_attributes={
-            "down": "down",
-            "up": "up",
         },
     ),
 ]

--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -1183,6 +1183,24 @@ STATIC_SENSORS: list[AREntityDescription] = [
             "xmask": "xmask",
         },
     ),
+    # DSL
+    ARSensorDescription(
+        key="datarate",
+        key_group="dsl",
+        name="DSL",
+        icon=ICON_ROUTER,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.DATA_RATE,
+        native_unit_of_measurement=UnitOfDataRate.BITS_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        suggested_display_precision=3,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        extra_state_attributes={
+            "down": "down",
+            "up": "up",
+        },
+    ),
 ]
 # Temperature sensors
 STATIC_SENSORS.extend(


### PR DESCRIPTION
Start to add datarate_down/up entity in HA sensors. **Not complete yet!**