### PR TITLE
Add Home Assistant static DHCP services

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,7 @@ jobs:
   codecov:
     name: Codecov
     needs: [unit-tests]
+    if: github.repository == 'Vaskivskyi/ha-asusrouter'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -1,0 +1,20 @@
+name: Validate HACS
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    name: HACS repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate integration repository
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/validate-hacs.yml
+++ b/.github/workflows/validate-hacs.yml
@@ -3,6 +3,8 @@ name: Validate HACS
 on:
   push:
   pull_request:
+  release:
+    types: [published]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a focused Home Assistant fork of
 It exists to add reliable fixed-IP management for ASUS routers while keeping
 the upstream integration's monitoring and control features.
 
-Current fork release: **v1.0.0-jgassens.1**.
+Current fork release: **v1.0.0+jgassens.1**.
 
 ## Problem
 
@@ -62,7 +62,7 @@ domain, so install only one of them.
    AsusRouter integration configuration or entities.
 3. In HACS, open **Custom repositories**.
 4. Add **https://github.com/jgassens/ha-asusrouter** as an **Integration**.
-5. Download **v1.0.0-jgassens.1** and restart Home Assistant.
+5. Download **v1.0.0+jgassens.1** and restart Home Assistant.
 
 Existing AsusRouter config entries and entity IDs remain in place because the
 domain is still **asusrouter**.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a focused Home Assistant fork of
 It exists to add reliable fixed-IP management for ASUS routers while keeping
 the upstream integration's monitoring and control features.
 
-Current fork release: **v1.0.0+jgassens.1**.
+Current fork release: **v1.0.0+jgassens.2**.
 
 ## Problem
 
@@ -47,8 +47,9 @@ more AsusRouter device trackers and choose:
 - **remove** to delete the parental-control rule.
 
 The action now validates its targets, routes each target through its owning
-router entry, and raises a visible Home Assistant error when the router does
-not accept the write or its state cannot be refreshed. Direct API callers may
+router entry, and confirms the requested state after refreshing the router.
+Already-achieved states are accepted, and removed rules no longer leave stale
+switch entities in Home Assistant. Direct API callers may
 also provide **devices** containing **mac** and optional **name**; when more
 than one router entry is loaded, they must also provide **config_entry_id**.
 
@@ -62,7 +63,7 @@ domain, so install only one of them.
    AsusRouter integration configuration or entities.
 3. In HACS, open **Custom repositories**.
 4. Add **https://github.com/jgassens/ha-asusrouter** as an **Integration**.
-5. Download **v1.0.0+jgassens.1** and restart Home Assistant.
+5. Download **v1.0.0+jgassens.2** and restart Home Assistant.
 
 Existing AsusRouter config entries and entity IDs remain in place because the
 domain is still **asusrouter**.

--- a/README.md
+++ b/README.md
@@ -1,231 +1,103 @@
-[![GitHub Release](https://img.shields.io/github/release/Vaskivskyi/ha-asusrouter.svg?style=for-the-badge&color=blue)](https://github.com/Vaskivskyi/ha-asusrouter/releases) [![License](https://img.shields.io/github/license/Vaskivskyi/ha-asusrouter.svg?style=for-the-badge&color=yellow)](LICENSE)<a href="https://github.com/Vaskivskyi/ha-asusrouter/actions/workflows/build.yaml"><img src="https://img.shields.io/github/actions/workflow/status/Vaskivskyi/ha-asusrouter/build.yaml?branch=main&style=for-the-badge" alt="Build Status" align="right" /></a><br/>
-[![HACS Default](https://img.shields.io/badge/HACS-default-blue.svg?style=for-the-badge)](https://hacs.xyz) [![Community forum discussion](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=for-the-badge&color=yellow)](https://community.home-assistant.io/t/custom-component-asusrouter-integration/416111)<a href="https://www.buymeacoffee.com/vaskivskyi" target="_blank"><img src="https://asusrouter.vaskivskyi.com/BuyMeACoffee.png" alt="Buy Me A Coffee" style="height: 28px !important;" align="right" /></a><br/>
-[![Installations](https://img.shields.io/endpoint?url=https://ha-analytics.vaskivskyi.com/badges/asusrouter/total.json&style=for-the-badge&color=blue)](https://github.com/Vaskivskyi/ha-custom-analytics)
+# AsusRouter Static DHCP Fork
 
-<div align=center><img src="https://asusrouter.vaskivskyi.com/logo.svg" width="300px"></div>
+This is a focused Home Assistant fork of
+[Vaskivskyi/ha-asusrouter](https://github.com/Vaskivskyi/ha-asusrouter).
+It exists to add reliable fixed-IP management for ASUS routers while keeping
+the upstream integration's monitoring and control features.
 
-## Monitor and control your AsusWRT-powered router from Home Assistant
+Current fork release: **v1.0.0-jgassens.1**.
 
-`AsusRouter` is a custom integration for Home Assistant to monitor and control your AsusWRT (and [AsusWRT-Merlin](https://www.asuswrt-merlin.net/))-powered router using the [AsusRouter](https://github.com/Vaskivskyi/asusrouter) python library.
+## Problem
 
-The integration uses the native HTTP(S) API (the same way as WebUI) and relies on direct communication with your device.
+The upstream integration can discover and monitor router clients, but it does
+not expose ASUS manual DHCP reservations in Home Assistant. Assigning a fixed
+IP therefore requires opening the router WebUI and editing each client there.
 
-## Documentation and tips
+## Solution
 
-You can find the full documentation on the [official webpage](https://asusrouter.vaskivskyi.com/).
+This fork adds static DHCP controls backed by the router's native HTTP(S)
+WebUI API. It reads and writes the same **dhcp_staticlist** configuration used
+by stock ASUS firmware, enables **dhcp_static_x**, and applies changes with
+**restart_dnsmasq**. Router SSH access is not required.
 
-### Use HTTPS connection
+The integration adds:
 
-It is recommended to use an HTTPS connection to your router (SSL). While both the SSL and non-SSL connections are fully supported, some devices might have issues with disconnects on HTTP. In order to use SSL, you need to enable it in the router settings: `Administration -> System -> Local Access Config -> Authentication Method`. Put it to `BOTH` (recommended) or `HTTPS`. Make note of the port number (default is `8443`).
+- A **Static DHCP reservations** sensor with the current reservation count and
+  lease list.
+- A **Reserve current IP** button on eligible tracked client devices.
+- **asusrouter.set_static_dhcp_lease** to create or replace a reservation.
+- **asusrouter.remove_static_dhcp_lease** to remove a reservation.
+- **asusrouter.reserve_current_ip** to reserve selected clients at their
+  currently reported addresses.
+- **asusrouter.refresh_static_dhcp_leases** to refresh Home Assistant's cached
+  reservation state.
 
-### Connected devices number
+Writes are guarded against duplicate IP assignments and are read back from the
+router after apply. Reserving the current IP will not silently move an existing
+reservation to a different address.
 
-The integration might show a different number of connected devices compared to the WebUI network map. In this case, refer to the number of devices shown in the `AiMesh` section of the WebUI. Those two are different regardless of the actual use of AiMesh.
+## Internet Access Action
 
-## :loudspeaker: Do you want to add AsusRouter to the default HA Core integrations?
+The existing **asusrouter.device_internet_access** action is retained and
+hardened in this release. In the Home Assistant action editor, select one or
+more AsusRouter device trackers and choose:
 
-:+1: Vote for the feature request!
+- **block** to enable a parental-control block.
+- **allow** to disable the block while retaining the rule.
+- **remove** to delete the parental-control rule.
 
-[Add AsusRouter integration to HA Core - Feature Requests - Home Assistant Community (home-assistant.io)](https://community.home-assistant.io/t/add-asusrouter-integration-to-ha-core/515756?u=vaskivskyi)
+The action now validates its targets, routes each target through its owning
+router entry, and raises a visible Home Assistant error when the router does
+not accept the write or its state cannot be refreshed. Direct API callers may
+also provide **devices** containing **mac** and optional **name**; when more
+than one router entry is loaded, they must also provide **config_entry_id**.
 
-## Firmware limitations
+## HACS Installation
 
-Firmware versions `3.0.0.4.x` and `3.0.0.6.x` are fully supported (older versions might have a limited amount of sensors available). When talking about the FW, `3.0.0.4` might be missed since it is the same all the time. Important is only the last part, e.g. `386.48631` or `102.xxxxx` for the stock or `386.7` for Merlin FW.
+This fork and the upstream repository use the same Home Assistant integration
+domain, so install only one of them.
 
-Firmware `5.x.x` (some DSL models) is **NOT supported** (not AsusWRT).
+1. Back up Home Assistant.
+2. Remove the official AsusRouter repository from HACS. Do not delete the
+   AsusRouter integration configuration or entities.
+3. In HACS, open **Custom repositories**.
+4. Add **https://github.com/jgassens/ha-asusrouter** as an **Integration**.
+5. Download **v1.0.0-jgassens.1** and restart Home Assistant.
 
-[More about firmware versions](https://asusrouter.vaskivskyi.com/guide/faq/#firmware)
+Existing AsusRouter config entries and entity IDs remain in place because the
+domain is still **asusrouter**.
 
-## Installation
+## Compatibility
 
-#### HACS
+- Home Assistant **2026.7.4** or newer for this release.
+- Stock AsusWRT **3.0.0.4.x** and **3.0.0.6.x**: expected and primary target.
+  Static DHCP was validated through the stock-compatible HTTP(S) WebUI path;
+  it does not depend on Merlin-only SSH commands.
+- AsusWRT-Merlin: expected to work where the upstream integration works,
+  because it exposes the same WebUI fields and apply action.
+- Asus firmware **5.x.x**: not supported, matching the upstream integration.
 
-You can add this repository to your HACS:
-`HACS -> Integrations -> Explore & Download Repositories -> AsusRouter`
+Router models and firmware vary. Make a router configuration backup before the
+first write and verify the resulting reservation in the ASUS WebUI.
 
-#### Manual
+## Upstream And Maintenance
 
-Copy content of the [stable branch](https://github.com/Vaskivskyi/ha-asusrouter/tree/stable) `custom_components/asusrouter/` to `custom_components/asusrouter/` in your Home Assistant folder.
+The fork is periodically rebased onto the current upstream **dev** branch. The
+static DHCP implementation depends on the companion
+[jgassens/asusrouter](https://github.com/jgassens/asusrouter) library fork,
+pinned to a tested commit in **manifest.json**.
 
-## Usage
+General AsusRouter behavior and device support come from the upstream project.
+Fork-specific DHCP or release issues belong in
+[jgassens/ha-asusrouter issues](https://github.com/jgassens/ha-asusrouter/issues).
 
-After AsusRouter is installed, you can add your device from Home Assistant UI.
+## Development
 
-[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=asusrouter)
+Run the test suite and lint checks before publishing:
 
-To connect to the device you need to provide the following data:
+    uv run pytest
+    uv run ruff check custom_components/asusrouter tests
+    uv run ruff format --check custom_components/asusrouter tests
 
-- IP address or hostname
-- Username (the one you use to log into the WebUI)
-- Password
-- Whether to use an SSL connection
-
-Almost all the integration settings can be reconfigured later via the `Configure` button on the Integrations' page without the need to remove your device and add it again.
-
-[![Open your Home Assistant instance and show your integrations.](https://my.home-assistant.io/badges/integrations.svg)](https://my.home-assistant.io/redirect/integrations/)
-
-## Features
-
-AsusRouter supports 14+ groups of features, including monitoring of:
-
-- connected device, CPU, guest WLAN, LED, Aura RGB, load average, network, OpenVPN, parental control, ports, RAM, temperature, WAN, WLAN.
-
-and control of:
-
-- guest WLAN, LED, Aura RGB, OpenVPN, parental control, WLAN.
-
-as well as the following HA platforms:
-
-- `binary_sensor`, `button`, `device_tracker`, `light`, `sensor`, `switch`, `update`
-
-and HA events and services.
-
-[Full list of features](https://asusrouter.vaskivskyi.com/features/)
-
-## Supported devices
-
-AsusRouter supports virtually every AsusWRT-powered device. This list is purely based on the reports from the users. Other devices with the compatible firmware should work as well.
-
-> [!TIP]  
-> Version `388.10` of AsusWRT-Merlin firmware is officially **NOT supported** due to the issues with HTTP daemon crashes. Use versions `>=388.10_2` or `<=388.9_2`.
-
-### WiFi 7 | 802.11be
-
-| Model                                                                           | Status              | Tested firmware            | Find it on Amazon[^amazon]                                                             |
-| ------------------------------------------------------------------------------- | ------------------- | -------------------------- | -------------------------------------------------------------------------------------- |
-| [GT-BE19000](https://asusrouter.vaskivskyi.com/devices/GT-BE19000.md)           | 💛 Expected to work |                            | <a href="https://amzn.to/3yGFU7U" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-BE98](https://asusrouter.vaskivskyi.com/devices/GT-BE98.md)                 | 💚 Confirmed        | Stock:<li>`102_34372`</li> | <a href="https://amzn.to/3vGztgz" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-BE98 Pro](https://asusrouter.vaskivskyi.com/devices/GT-BE98Pro.md)          | 💛 Expected to work |                            | <a href="https://amzn.to/3uoSjeR" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-BE58U](https://asusrouter.vaskivskyi.com/devices/RT-BE58U.md)               | 💛 Expected to work |                            | <a href="https://amzn.to/4bHsdo4" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-BE88U](https://asusrouter.vaskivskyi.com/devices/RT-BE88U.md)               | 💛 Expected to work |                            | <a href="https://amzn.to/3TAGCKY" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-BE92U](https://asusrouter.vaskivskyi.com/devices/RT-BE92U.md)               | 💛 Expected to work |                            | <a href="https://amzn.to/4c1E8gg" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-BE96U](https://asusrouter.vaskivskyi.com/devices/RT-BE96U.md)               | 💛 Expected to work |                            | <a href="https://amzn.to/3vJu8oD" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-BE3600](https://asusrouter.vaskivskyi.com/devices/TUF-BE3600.md)           | 💛 Expected to work |                            | <a href="https://amzn.to/3VhHoyt" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-BE6500](https://asusrouter.vaskivskyi.com/devices/TUF-BE6500.md)           | 💛 Expected to work |                            | <a href="https://amzn.to/3X3Xltv" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi BD4](https://asusrouter.vaskivskyi.com/devices/ZenWiFiBD4.md)          | 💛 Expected to work |                            | <a href="https://amzn.to/3Kfulr1" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi BQ16](https://asusrouter.vaskivskyi.com/devices/ZenWiFiBQ16.md)        | 💛 Expected to work |                            | <a href="https://amzn.to/4bgVvdo" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi BQ16 Pro](https://asusrouter.vaskivskyi.com/devices/ZenWiFiBQ16Pro.md) | 💛 Expected to work |                            | <a href="https://amzn.to/3MNcw48" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi BT10](https://asusrouter.vaskivskyi.com/devices/ZenWiFiBT10.md)        | 💛 Expected to work |                            | <a href="https://amzn.to/48F5wiB" rel="nofollow sponsored" target="_blank">find it</a> |
-
-### WiFi 6e | 802.11axe
-
-| Model                                                                           | Status              | Tested firmware                                                                   | Find it on Amazon[^amazon]                                                             |
-| ------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [GT-AXE11000](https://asusrouter.vaskivskyi.com/devices/GT-AXE11000.md)         | 💛 Expected to work |                                                                                   | <a href="https://amzn.to/3Gotj9R" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-AXE16000](https://asusrouter.vaskivskyi.com/devices/GT-AXE16000.md)         | 💚 Confirmed        | Stock:<li>`388.21617`</li>Merlin:<li>`388.7_beta1_rog`</li><li>`388.7_0_rog`</li> | <a href="https://amzn.to/3vObLyZ" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AXE7800](https://asusrouter.vaskivskyi.com/devices/RT-AXE7800.md)           | 💚 Confirmed        | Stock:<li>`388_22068`</li>                                                        | <a href="https://amzn.to/3jUr2LU" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi ET8](https://asusrouter.vaskivskyi.com/devices/ZenWiFiET8.md)          | 💚 Confirmed        | Stock:<li>`388.23759`</li>                                                        | <a href="https://amzn.to/3Iks0La" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi ET9](https://asusrouter.vaskivskyi.com/devices/ZenWiFiET9.md)          | 💛 Expected to work |                                                                                   | <a href="https://amzn.to/3RbMKJa" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi Pro ET12](https://asusrouter.vaskivskyi.com/devices/ZenWiFiProET12.md) | 💚 Confirmed        | Stock:<li>`388.23013`</li>                                                        | <a href="https://amzn.to/3GTz68P" rel="nofollow sponsored" target="_blank">find it</a> |
-
-### WiFi 6 | 802.11ax
-
-| Model                                                                                          | Status              | Tested firmware                                                                                                                                                                       | Find it on Amazon[^amazon]                                                             |
-| ---------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [DSL-AX82U](https://asusrouter.vaskivskyi.com/devices/DSL-AX82U.md)                            | 💚 Confirmed        | Merlin:<li>`386.07_0-gnuton0_beta2`</li>                                                                                                                                              | <a href="https://amzn.to/3G87vyR" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-AX11000](https://asusrouter.vaskivskyi.com/devices/GT-AX11000.md)                          | 💚 Confirmed        | Merlin:<li>`386.7_2`</li><li>`388.1_0`</li><li>`388.4_0`</li><li>`388.7_0_rog`</li>                                                                                                   | <a href="https://amzn.to/3WDzOMT" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-AX11000 Pro](https://asusrouter.vaskivskyi.com/devices/GT-AX11000Pro.md)                   | 💚 Confirmed        | Stock:<li>`388.24198`</li>Merlin:<li>`388.7_0_rog`</li>                                                                                                                               | <a href="https://amzn.to/3VUNbHl" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT-AX6000](https://asusrouter.vaskivskyi.com/devices/GT-AX6000.md)                            | 💛 Expected to work | Merlin:<li>`388.7_beta1`</li>                                                                                                                                                         | <a href="https://amzn.to/3GrKHKG" rel="nofollow sponsored" target="_blank">find it</a> |
-| [GT6](https://asusrouter.vaskivskyi.com/devices/GT6.md)                                        | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3GmPCfR" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RP-AX56](https://asusrouter.vaskivskyi.com/devices/RP-AX56.md)                                | 💚 Confirmed        |                                                                                                                                                                                       | <a href="https://amzn.to/3MpZSY8" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX3000P](https://asusrouter.vaskivskyi.com/devices/RT-AX3000P.md)                          | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3RPa2UO" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX52](https://asusrouter.vaskivskyi.com/devices/RT-AX52.md)                                | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/40Ph3sO" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX53U](https://asusrouter.vaskivskyi.com/devices/RT-AX53U.md)                              | 💚 Confirmed        | Stock:<li>`386.69061`</li>                                                                                                                                                            | <a href="https://amzn.to/49jEgqO" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX5400](https://asusrouter.vaskivskyi.com/devices/RT-AX5400.md)                            | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/4aCdvyu" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX55](https://asusrouter.vaskivskyi.com/devices/RT-AX55.md)                                | 💚 Confirmed        | Stock:<li>`386.50410`</li><li>`386.52041`</li>                                                                                                                                        | <a href="https://amzn.to/3Z2ath5" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX56U](https://asusrouter.vaskivskyi.com/devices/RT-AX56U.md)                              | 💚 Confirmed        | Merlin:<li>`386.7_2`</li><li>`388.1_0`</li><li>`388.2_2`</li>                                                                                                                         | <a href="https://amzn.to/3vrIeuz" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX57](https://asusrouter.vaskivskyi.com/devices/RT-AX57.md)                                | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3IWnZNx" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX57 Go](https://asusrouter.vaskivskyi.com/devices/RT-AX57Go.md)                           | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/47kE9db" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX57M](https://asusrouter.vaskivskyi.com/devices/RT-AX57M.md)                              | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3vbVl6k" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX58U](https://asusrouter.vaskivskyi.com/devices/RT-AX58U.md)                              | 💚 Confirmed        | Stock:<li>`386.49674`</li><li>`388.22237`</li>Merlin:<li>`386.7_2`</li><li>`388.1_0`</li><li>`388.4_0`</li><li>`388.7.0`</li>                                                         | <a href="https://amzn.to/3jHri0L" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX59U](https://asusrouter.vaskivskyi.com/devices/RT-AX59U.md)                              | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3CVCVYO" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX68U](https://asusrouter.vaskivskyi.com/devices/RT-AX68U.md)                              | 💚 Confirmed        | Stock:<li>`388.21732`</li>                                                                                                                                                            | <a href="https://amzn.to/3WzRwk5" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX82U](https://asusrouter.vaskivskyi.com/devices/RT-AX82U.md)                              | 💚 Confirmed        | Stock:<li>`386.48664`</li><li>`386.49674`</li>Merlin:<li>`388.8_4-gnuton1`</li>                                                                                                       | <a href="https://amzn.to/3Gv2Bxi" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX86S](https://asusrouter.vaskivskyi.com/devices/RT-AX86S.md)                              | 💚 Confirmed        | Stock:<li>`386.46061`</li><li>`386.48260`</li><li>`386.49447`</li><li>`388.22525`</li>Merlin:<li>`386.7_2`</li>                                                                       | <a href="https://amzn.to/3GuKac5" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX86U](https://asusrouter.vaskivskyi.com/devices/RT-AX86U.md)                              | 💚 Confirmed        | Stock:<li>`386.46061`</li><li>`386.48260`</li><li>`386.49447`</li><li>`388.22525`</li>Merlin:<li>`386.7_2`</li><li>`388.4_0`</li><li>`388.7_beta1`</li>                               | <a href="https://amzn.to/3WCBcPO" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX86U Pro](https://asusrouter.vaskivskyi.com/devices/RT-AX86UPro.md)                       | 💚 Confirmed        | Stock:<li>`388.23565`</li>                                                                                                                                                            | <a href="https://amzn.to/3ZDM41T" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX88U](https://asusrouter.vaskivskyi.com/devices/RT-AX88U.md)                              | 💚 Confirmed        | Stock:<li>`386.45934`</li><li>`386.48631`</li><li>`388.24198`</li>Merlin:<li>`386.5_2`</li><li>`386.8_0`</li><li>`388.1_0`</li><li>`388.2_0`</li><li>`388.4_0`</li><li>`388.7_0`</li> | <a href="https://amzn.to/3i2VfYu" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX88U Pro](https://asusrouter.vaskivskyi.com/devices/RT-AX88UPro.md)                       | 💚 Confirmed        | Merlin:<li>`388.4_0`</li>                                                                                                                                                             | <a href="https://amzn.to/3QNDpFZ" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX89X](https://asusrouter.vaskivskyi.com/devices/RT-AX89X.md)                              | 💚 Confirmed        |                                                                                                                                                                                       | <a href="https://amzn.to/3i55b3S" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AX92U](https://asusrouter.vaskivskyi.com/devices/RT-AX92U.md)                              | 💚 Confirmed        | Stock:<li>`386.46061`</li>                                                                                                                                                            | <a href="https://amzn.to/3jJJgzt" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-AX3000 V2](https://asusrouter.vaskivskyi.com/devices/TUF-AX3000V2.md)                     | 💚 Confirmed        | Stock:<li>`388.23785`</li>                                                                                                                                                            | <a href="https://amzn.to/3QzzD4C" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-AX4200](https://asusrouter.vaskivskyi.com/devices/TUF-AX4200.md)                          | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3kexPjC" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-AX5400](https://asusrouter.vaskivskyi.com/devices/TUF-AX5400.md)                          | 💚 Confirmed        | Stock:<li>`386.50224`</li><li>`388.21224`</li><li>`388.22525`</li><li>`388.23285`</li><li>`388.24121`</li>Merlin:<li>`388.4_0`</li>                                                   | <a href="https://amzn.to/3hXgzyQ" rel="nofollow sponsored" target="_blank">find it</a> |
-| [TUF-AX6000](https://asusrouter.vaskivskyi.com/devices/TUF-AX6000.md)                          | 💚 Confirmed        | Stock:<li>`388.32432`</li>                                                                                                                                                            | <a href="https://amzn.to/3CXqxaG" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi AX (XT8)](<https://asusrouter.vaskivskyi.com/devices/ZenWiFiAX(XT8).md>)              | 💚 Confirmed        | Stock:<li>`386.48706`</li><li>`388.23285`</li>Merlin:<li>`386.7_2-gnuton1`</li>                                                                                                       | <a href="https://amzn.to/3GuvY2L" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi AX Hybrid (XP4)](<https://asusrouter.vaskivskyi.com/devices/ZenWiFiAXHybrid(XP4).md>) | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3Itxnbb" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi AX Mini (XD4)](<https://asusrouter.vaskivskyi.com/devices/ZenWiFiAXMini(XD4).md>)     | 💚 Confirmed        | Stock:<li>`386.48790`</li><li>`386.49599`</li>                                                                                                                                        | <a href="https://amzn.to/3hYGuGl" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi Pro XT12](https://asusrouter.vaskivskyi.com/devices/ZenWiFiProXT12.md)                | 💚 Confirmed        | Stock:<li>`388.22127`</li>                                                                                                                                                            | <a href="https://amzn.to/3im6UC5" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XD4 Plus](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXD4Plus.md)                | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3XtYOWp" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XD4S](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXD4S.md)                       | 💛 Expected to work |                                                                                                                                                                                       | <a href="https://amzn.to/3E341xI" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XD5](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXD5.md)                         | 💚 Confirmed        | Stock:<li>`388.23949`</li>                                                                                                                                                            | <a href="https://amzn.to/3YrhgjM" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XD6](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXD6.md)                         | 💚 Confirmed        | Stock:<li>`388.21380`</li>                                                                                                                                                            | <a href="https://amzn.to/3jW23s4" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XD6S](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXD6S.md)                       | 💚 Confirmed        | Stock:<li>`388.21380`</li>                                                                                                                                                            | <a href="https://amzn.to/3YMbyIZ" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi XT9](https://asusrouter.vaskivskyi.com/devices/ZenWiFiXT9.md)                         | 💚 Confirmed        | Stock:<li>`388_23285`</li>                                                                                                                                                            | <a href="https://amzn.to/3JZOgLF" rel="nofollow sponsored" target="_blank">find it</a> |
-
-### WiFi 5 | 802.11ac
-
-| Model                                                                                     | Status              | Tested firmware                                                                                             | Find it on Amazon[^amazon]                                                             |
-| ----------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [4G-AC55U](https://asusrouter.vaskivskyi.com/devices/4G-AC55U.md)                         | 💚 Confirmed        | Stock:<li>`380.8102`</li>                                                                                   | <a href="https://amzn.to/3jIWQDu" rel="nofollow sponsored" target="_blank">find it</a> |
-| [BRT-AC828](https://asusrouter.vaskivskyi.com/devices/BRT-AC828.md)                       | 💚 Confirmed        | Stock:<li>`382_70348`</li>                                                                                  | <a href="https://amzn.to/3X2wSL5" rel="nofollow sponsored" target="_blank">find it</a> |
-| [DSL-AC68U](https://asusrouter.vaskivskyi.com/devices/DSL-AC68U.md)                       | 💚 Confirmed        | Stock:<li>`386.47534`</li><li>`386.50117`</li>Merlin:<li>`386.4-gnuton2`</li><li>`386.7_2-gnuton1`</li>     | <a href="https://amzn.to/3Z5k32H" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC51U](https://asusrouter.vaskivskyi.com/devices/RT-AC51U.md)                         | 💚 Confirmed        | Stock:<li>`380.8591`</li>                                                                                   | <a href="https://amzn.to/3WMy2sq" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC52U B1](https://asusrouter.vaskivskyi.com/devices/RT-AC52UB1.md)                    | 💚 Confirmed        |                                                                                                             | <a href="https://amzn.to/3QcrCkk" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC5300](https://asusrouter.vaskivskyi.com/devices/RT-AC5300.md)                       | 💚 Confirmed        | Merlin:<li>`386.7_2`</li>                                                                                   | <a href="https://amzn.to/3ZcJQpY" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC57U V3](https://asusrouter.vaskivskyi.com/devices/RT-AC57UV3.md)                    | 💚 Confirmed        | Stock:<li>`386.21649`</li>                                                                                  | <a href="https://amzn.to/3VAxDbx" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC58U](https://asusrouter.vaskivskyi.com/devices/RT-AC58U.md)                         | 💚 Confirmed        |                                                                                                             | <a href="https://amzn.to/3G98Mpl" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC66U](https://asusrouter.vaskivskyi.com/devices/RT-AC66U.md)                         | 💚 Confirmed        | Merlin:<li>`380.70_0`</li>                                                                                  | <a href="https://amzn.to/3WTtTD8" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC66U B1](https://asusrouter.vaskivskyi.com/devices/RT-AC66UB1.md)                    | 💚 Confirmed        | Stock:<li>`386.51255`</li>                                                                                  | <a href="https://amzn.to/3vtZ4Jm" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC68U](https://asusrouter.vaskivskyi.com/devices/RT-AC68U.md)                         | 💚 Confirmed        | Stock:<li>`386.49703`</li>Merlin:<li>`386.5_2`</li><li>`386.7_0`</li>                                       | <a href="https://amzn.to/3i6dQTE" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC85P](https://asusrouter.vaskivskyi.com/devices/RT-AC85P.md)                         | 💚 Confirmed        | Stock:<li>`382.52516`</li>                                                                                  | <a href="https://amzn.to/3kMiDdU" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC86U](https://asusrouter.vaskivskyi.com/devices/RT-AC86U.md)                         | 💚 Confirmed        | Stock:<li>`386.48260`</li><li>`386.49709`</li>Merlin:<li>`386.7_0`</li><li>`386.7_2`</li><li>`386.9_0`</li> | <a href="https://amzn.to/3CbRarK" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC87U](https://asusrouter.vaskivskyi.com/devices/RT-AC87U.md)                         | 💚 Confirmed        | Merlin:<li>`384.13_10`</li>                                                                                 | <a href="https://amzn.to/3i4sUkE" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-AC88U](https://asusrouter.vaskivskyi.com/devices/RT-AC88U.md)                         | 💚 Confirmed        | Stock:<li>`386.48260`</li>Merlin:<li>`386.5_0`</li><li>`386.7_beta1`</li><li>`386.12_2`</li>                | <a href="https://amzn.to/3FYRYBy" rel="nofollow sponsored" target="_blank">find it</a> |
-| [RT-ACRH17](https://asusrouter.vaskivskyi.com/devices/RT-ACRH17.md)                       | 💚 Confirmed        | Stock:<li>`382.52517`</li>                                                                                  | <a href="https://amzn.to/3i6dWL0" rel="nofollow sponsored" target="_blank">find it</a> |
-| [ZenWiFi AC Mini(CD6)](<https://asusrouter.vaskivskyi.com/devices/ZenWiFiACMini(CD6).md>) | 💛 Expected to work |                                                                                                             | <a href="https://amzn.to/3RU7vrL" rel="nofollow sponsored" target="_blank">find it</a> |
-
-### WiFi 4 | 802.11n
-
-| Model                                                           | Status       | Tested firmware | Find it on Amazon[^amazon]                                                             |
-| --------------------------------------------------------------- | ------------ | --------------- | -------------------------------------------------------------------------------------- |
-| [RT-N66U](https://asusrouter.vaskivskyi.com/devices/RT-N66U.md) | 💚 Confirmed |                 | <a href="https://amzn.to/3i7eP5Z" rel="nofollow sponsored" target="_blank">find it</a> |
-
-## New features development
-
-Here is the list of features being in process of development or considered for the future development. If you cannot find the feature you would like to have in the integration, please, open a [new feature request](https://github.com/Vaskivskyi/ha-asusrouter/issues/new/choose).
-
-<table>
-
-<tr><th>Group</th><th>Feature</th><th>Status</th></tr>
-
-<tr><td>Connected device</td><td><ol>
-<li>Per-device traffic monitoring (<a href="https://github.com/Vaskivskyi/ha-asusrouter/issues/220">#220</a>)</li>
-<li>Possibility to use DHCP `hostname` value for device tracking (<a href="https://github.com/Vaskivskyi/ha-asusrouter/issues/119">#119</a>)</li>
-</ol></td><td>
-<b>considered</b>
-</td></tr>
-
-</table>
-
-## Support the integration
-
-### Issues and Pull requests
-
-If you have found an issue working with the integration or just want to ask for a new feature, please fill in a new [issue](https://github.com/Vaskivskyi/ha-asusrouter/issues/new/choose).
-
-You are also welcome to submit [pull requests](https://github.com/Vaskivskyi/ha-asusrouter/pulls) to the repository!
-
-### Other support
-
-This integration is a free-time project. If you like it, you can support me by buying a coffee.
-
-<a href="https://www.buymeacoffee.com/vaskivskyi" target="_blank"><img src="https://asusrouter.vaskivskyi.com/BuyMeACoffee.png" alt="Buy Me A Coffee" style="height: 60px !important;"></a>
-
-Moreover, you can support the integration by using the Amazon links provided in the device lists. Any purchase (even not related to the exact product) might bring a small commission to the project.
-
-## Thanks to
-
-The initial codebase (from April 2022) for this integration is highly based on Home Assistant core integration [AsusWRT](https://www.home-assistant.io/integrations/asuswrt/) and [ollo69/ha_asuswrt_custom](https://github.com/ollo69/ha_asuswrt_custom).
-
-[^amazon]: As an Amazon Associate I earn from qualifying purchases. Not like I ever got anything yet (:
+This project remains licensed under Apache-2.0. Upstream authorship and history
+are preserved in Git.

--- a/custom_components/asusrouter/__init__.py
+++ b/custom_components/asusrouter/__init__.py
@@ -8,11 +8,23 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.typing import ConfigType
 
 from .const import ASUSROUTER, DOMAIN, PLATFORMS, STOP_LISTENER
 from .router import ARDevice
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(
+    hass: HomeAssistant,
+    config: ConfigType,
+) -> bool:
+    """Set up AsusRouter integration."""
+
+    await async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(

--- a/custom_components/asusrouter/__init__.py
+++ b/custom_components/asusrouter/__init__.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 
@@ -15,6 +16,8 @@ from .router import ARDevice
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(

--- a/custom_components/asusrouter/binary_sensor.py
+++ b/custom_components/asusrouter/binary_sensor.py
@@ -10,19 +10,25 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .client import ARClient
 from .const import (
     AIMESH,
     ASUSROUTER,
     CONF_DEFAULT_HIDE_PASSWORDS,
     CONF_HIDE_PASSWORDS,
+    DNS,
     DOMAIN,
+    IP,
+    MAC,
     MANUFACTURER,
     PASSWORD,
+    ROUTER,
     STATIC_BINARY_SENSORS,
 )
 from .dataclass import ARBinarySensorDescription
@@ -57,18 +63,31 @@ async def async_setup_entry(
 
     router = hass.data[DOMAIN][config_entry.entry_id][ASUSROUTER]
     tracked: set = set()
+    client_tracked: set = set()
 
     @callback
-    def update_router():
+    def update_router() -> None:
         """Update the values of the router."""
 
         add_entities(router, async_add_entities, tracked)
 
+    @callback
+    def update_clients() -> None:
+        """Add static DHCP client sensors."""
+
+        add_static_dhcp_entities(router, async_add_entities, client_tracked)
+
     router.async_on_close(
         async_dispatcher_connect(hass, router.signal_aimesh_new, update_router)
     )
+    router.async_on_close(
+        async_dispatcher_connect(
+            hass, router.signal_device_new, update_clients
+        )
+    )
 
     update_router()
+    update_clients()
 
 
 class ARBinarySensor(ARBinaryEntity, BinarySensorEntity):
@@ -101,6 +120,37 @@ def add_entities(
             continue
 
         new_tracked.append(AMBinarySensor(router, node))
+        tracked.add(mac)
+
+    if new_tracked:
+        async_add_entities(new_tracked)
+
+
+def _client_entity_enabled(router: ARDevice, client: ARClient) -> bool:
+    """Return whether client-scoped entities should be created."""
+
+    return router.create_devices is True or (
+        router.client_device is True and client.device is True
+    )
+
+
+@callback
+def add_static_dhcp_entities(
+    router: ARDevice,
+    async_add_entities: AddEntitiesCallback,
+    tracked: set[str],
+) -> None:
+    """Add static DHCP reservation sensors for known client devices."""
+
+    if router.mode != ROUTER:
+        return
+
+    new_tracked = []
+    for mac, client in router.devices.items():
+        if mac in tracked or not _client_entity_enabled(router, client):
+            continue
+
+        new_tracked.append(ClientStaticDHCPReservationSensor(router, client))
         tracked.add(mac)
 
     if new_tracked:
@@ -184,6 +234,90 @@ class AMBinarySensor(BinarySensorEntity):
             async_dispatcher_connect(
                 self.hass,
                 self._router.signal_aimesh_update,
+                self.async_on_demand_update,
+            )
+        )
+
+
+class ClientStaticDHCPReservationSensor(BinarySensorEntity):
+    """Client static DHCP reservation sensor."""
+
+    _attr_icon = "mdi:ip-network-outline"
+
+    def __init__(
+        self,
+        router: ARDevice,
+        client: ARClient,
+    ) -> None:
+        """Initialize static DHCP reservation sensor."""
+
+        self._router = router
+        self._client = client
+        self._mac = dr.format_mac(client.mac_address)
+        self._attr_unique_id = to_unique_id(
+            f"{router.mac}_{self._mac}_dhcp_reservation"
+        )
+        self._attr_name = (
+            f"{client.name or client.mac_address} DHCP Reservation"
+        )
+        self._attr_device_info = self._compile_device_info()
+
+    def _compile_device_info(self) -> DeviceInfo:
+        """Compile client device info."""
+
+        return DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, self._mac)},
+            default_name=self._client.name or self._mac,
+            via_device=(DOMAIN, self._router.mac),
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the client has a static DHCP reservation."""
+
+        return self._router.static_dhcp_reservation(self._mac) is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return reservation details."""
+
+        reservation = self._router.static_dhcp_reservation(self._mac)
+        reserved_ip = reservation[IP] if reservation else None
+        current_ip = self._client.ip_address
+
+        return {
+            MAC: self._mac,
+            "reserved_ip": reserved_ip,
+            "current_ip": current_ip,
+            "hostname": reservation["hostname"] if reservation else None,
+            DNS: reservation[DNS] if reservation else None,
+            "matches_current_ip": (
+                reserved_ip is not None and reserved_ip == current_ip
+            ),
+        }
+
+    @callback
+    def async_on_demand_update(self) -> None:
+        """Update the client reservation sensor."""
+
+        if self._mac in self._router.devices:
+            self._client = self._router.devices[self._mac]
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callbacks."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_device_update,
+                self.async_on_demand_update,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_static_dhcp_update,
                 self.async_on_demand_update,
             )
         )

--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import dataclasses
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 from asusrouter import AsusRouter
@@ -443,6 +443,72 @@ class ARBridge:
         """Get clients."""
 
         return await self._get_data(AsusData.CLIENTS, force=True)
+
+    # Static DHCP leases
+    async def async_get_static_dhcp_leases(self) -> list[Any]:
+        """Get static DHCP leases."""
+
+        try:
+            return cast(
+                list[Any], await self.api.async_get_static_dhcp_leases()
+            )
+        except AttributeError as ex:
+            raise UpdateFailed(
+                "Installed asusrouter package does not support "
+                "static DHCP leases"
+            ) from ex
+        except AsusRouterError as ex:
+            raise UpdateFailed(ex) from ex
+
+    async def async_set_static_dhcp_lease(
+        self,
+        mac: str,
+        ip: str,
+        hostname: str | None = None,
+        dns: str | None = None,
+    ) -> bool:
+        """Set a static DHCP lease."""
+
+        try:
+            return cast(
+                bool,
+                await self.api.async_set_static_dhcp_lease(
+                    mac=mac,
+                    ip=ip,
+                    hostname=hostname,
+                    dns=dns,
+                ),
+            )
+        except AttributeError as ex:
+            raise UpdateFailed(
+                "Installed asusrouter package does not support "
+                "static DHCP leases"
+            ) from ex
+        except AsusRouterError as ex:
+            raise UpdateFailed(ex) from ex
+
+    async def async_remove_static_dhcp_lease(
+        self,
+        mac: str,
+        apply: bool = True,
+    ) -> list[Any]:
+        """Remove a static DHCP lease."""
+
+        try:
+            return cast(
+                list[Any],
+                await self.api.async_remove_static_dhcp_lease(
+                    mac=mac,
+                    apply=apply,
+                ),
+            )
+        except AttributeError as ex:
+            raise UpdateFailed(
+                "Installed asusrouter package does not support "
+                "static DHCP leases"
+            ) from ex
+        except AsusRouterError as ex:
+            raise UpdateFailed(ex) from ex
 
     # Sensor-specific methods
     async def _get_data_aura(self) -> dict[str, Any]:

--- a/custom_components/asusrouter/bridge.py
+++ b/custom_components/asusrouter/bridge.py
@@ -31,7 +31,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -835,18 +834,14 @@ class ARBridge:
             type=rule_type,
         )
 
-    async def async_pc_rule(self, **kwargs: Any) -> bool:  # noqa: C901, PLR0912
+    async def async_pc_rule(
+        self,
+        *,
+        state: str,
+        devices: list[dict[str, Any]],
+    ) -> bool:
         """Change parental control rule(s)."""
 
-        # Get the passed data
-        raw = kwargs.get("raw")
-
-        # Abort if no data is passed
-        if raw is None:
-            return False
-
-        # Get the state to set
-        state = raw.get("state", None)
         match state:
             case a if a in ("disable", "allow"):
                 rule_type = PCRuleType.DISABLE
@@ -858,40 +853,25 @@ class ARBridge:
                 _LOGGER.warning("Unknown parental control state: %s", state)
                 return False
 
-        # Get the targets to set
-        devices = raw.get("devices", [])
-        entities = raw.get("entities", [])
+        rules_to_set = [
+            rule
+            for device in devices
+            if (rule := self._pc_device2rule(device, rule_type)) is not None
+        ]
+        if not rules_to_set:
+            _LOGGER.warning("No valid parental control targets were provided")
+            return False
 
-        # Prepare the rules list
-        rules_to_set = []
-
-        # Process entities if any
-        if len(entities) > 0:
-            entity_reg = er.async_get(self.hass)
-            for entity in entities:
-                reg_value = entity_reg.async_get(entity)
-                if not isinstance(reg_value, er.RegistryEntry):
-                    continue
-                capabilities: dict[str, Any] = helpers.as_dict(
-                    reg_value.capabilities
-                )
-                devices.append(capabilities)
-
-        # Convert devices to rules
-        for device in devices:
-            rule = self._pc_device2rule(device, rule_type)
-            if rule is not None:
-                rules_to_set.append(rule)
-
-        # Set the rules
+        success = True
         for rule in rules_to_set:
             result = await self.api.async_set_state(rule)
             if result is True:
                 _LOGGER.debug("Parental control rule set: %s", rule)
             else:
                 _LOGGER.warning("Cannot set parental control rule: %s", rule)
+                success = False
 
-        return True
+        return success
 
     # --------------------
     # <-- Services

--- a/custom_components/asusrouter/button.py
+++ b/custom_components/asusrouter/button.py
@@ -8,13 +8,20 @@ from typing import Any
 from asusrouter.modules.state import AsusState
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .client import ARClient
 from .const import (
     ASUSROUTER,
     CONF_MODE,
     DOMAIN,
+    ICON_IP,
+    IP,
+    MAC,
     ROUTER,
     STATIC_BUTTONS,
     STATIC_BUTTONS_OPTIONAL,
@@ -48,6 +55,51 @@ async def async_setup_entry(
             _LOGGER.warning(ex)
 
     async_add_entities(entities)
+
+    tracked: set = set()
+
+    @callback
+    def update_router() -> None:
+        """Add static DHCP client buttons."""
+
+        add_static_dhcp_entities(router, async_add_entities, tracked)
+
+    router.async_on_close(
+        async_dispatcher_connect(hass, router.signal_device_new, update_router)
+    )
+
+    update_router()
+
+
+def _client_entity_enabled(router: ARDevice, client: ARClient) -> bool:
+    """Return whether client-scoped entities should be created."""
+
+    return router.create_devices is True or (
+        router.client_device is True and client.device is True
+    )
+
+
+@callback
+def add_static_dhcp_entities(
+    router: ARDevice,
+    async_add_entities: AddEntitiesCallback,
+    tracked: set[str],
+) -> None:
+    """Add static DHCP buttons for known client devices."""
+
+    if router.mode != ROUTER:
+        return
+
+    new_tracked = []
+    for mac, client in router.devices.items():
+        if mac in tracked or not _client_entity_enabled(router, client):
+            continue
+
+        new_tracked.append(ClientStaticDHCPReserveButton(router, client))
+        tracked.add(mac)
+
+    if new_tracked:
+        async_add_entities(new_tracked)
 
 
 class ARButton(ButtonEntity):
@@ -106,3 +158,103 @@ class ARButton(ButtonEntity):
                 _LOGGER.debug("Didn't manage to press %s", state)
         except Exception as ex:  # noqa: BLE001
             _LOGGER.error("Pressing %s caused an exception: %s", state, ex)
+
+
+class ClientStaticDHCPReserveButton(ButtonEntity):
+    """Button to reserve a client's current IP address."""
+
+    _attr_icon = ICON_IP
+
+    def __init__(
+        self,
+        router: ARDevice,
+        client: ARClient,
+    ) -> None:
+        """Initialize the reserve current IP button."""
+
+        self._router = router
+        self._client = client
+        self._mac = dr.format_mac(client.mac_address)
+        self._attr_unique_id = to_unique_id(
+            f"{router.mac}_{self._mac}_reserve_current_ip"
+        )
+        self._attr_name = (
+            f"{client.name or client.mac_address} Reserve Current IP"
+        )
+        self._attr_device_info = self._compile_device_info()
+
+    def _compile_device_info(self) -> DeviceInfo:
+        """Compile client device info."""
+
+        return DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, self._mac)},
+            default_name=self._client.name or self._mac,
+            via_device=(DOMAIN, self._router.mac),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if the button can safely reserve the current IP."""
+
+        current_ip = self._client.ip_address
+        if current_ip is None:
+            return False
+
+        if self._router.static_dhcp_ip_conflict(self._mac, current_ip):
+            return False
+
+        reservation = self._router.static_dhcp_reservation(self._mac)
+        return reservation is None or reservation[IP] == current_ip
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return button attributes."""
+
+        reservation = self._router.static_dhcp_reservation(self._mac)
+        return {
+            MAC: self._mac,
+            "current_ip": self._client.ip_address,
+            "reserved_ip": reservation[IP] if reservation else None,
+        }
+
+    async def async_press(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        """Reserve the current IP address."""
+
+        if self._client.ip_address is None:
+            return
+
+        await self._router.async_reserve_current_ip(
+            mac=self._mac,
+            ip=self._client.ip_address,
+            hostname=self._client.name,
+        )
+        self.async_write_ha_state()
+
+    @callback
+    def async_on_demand_update(self) -> None:
+        """Update the client button."""
+
+        if self._mac in self._router.devices:
+            self._client = self._router.devices[self._mac]
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callbacks."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_device_update,
+                self.async_on_demand_update,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._router.signal_static_dhcp_update,
+                self.async_on_demand_update,
+            )
+        )

--- a/custom_components/asusrouter/compilers.py
+++ b/custom_components/asusrouter/compilers.py
@@ -31,8 +31,7 @@ def list_sensors_network(
                     key=key,
                     key_group=NETWORK,
                     name=f"{CONF_LABELS_INTERFACES.get(interface, interface)} "
-                    f"{data[NAME]}"
-                    or None,
+                    f"{data[NAME]}",
                     icon=data["icon"] or None,
                     state_class=data["state_class"] or None,
                     device_class=data["device_class"] or None,

--- a/custom_components/asusrouter/const.py
+++ b/custom_components/asusrouter/const.py
@@ -148,6 +148,7 @@ SENSORS = "sensors"
 SSID = "ssid"
 SSL = "ssl"
 STATE = "state"
+STATIC_DHCP = "static_dhcp"
 STATUS = "status"
 SYSINFO = "sysinfo"
 TEMPERATURE = "temperature"
@@ -311,6 +312,7 @@ SENSORS_CONNECTED_DEVICES = [
     "latest_time",
     "gn_number",
 ]
+SENSORS_STATIC_DHCP = [NUMBER]
 SENSORS_CPU = [TOTAL, USED, USAGE]
 SENSORS_FIRMWARE = [STATE, "state_beta"]
 SENSORS_GWLAN = {
@@ -1146,6 +1148,19 @@ STATIC_SENSORS: list[AREntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=True,
         extra_state_attributes={},
+    ),
+    # Static DHCP leases
+    ARSensorDescription(
+        key=NUMBER,
+        key_group=STATIC_DHCP,
+        name="Static DHCP Leases",
+        icon=ICON_IP,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=True,
+        extra_state_attributes={
+            LIST: "leases",
+        },
     ),
     # CPU
     ARSensorDescription(

--- a/custom_components/asusrouter/entity.py
+++ b/custom_components/asusrouter/entity.py
@@ -27,7 +27,7 @@ from .router import ARDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_ar_entry(  # noqa: PLR0913
+async def async_setup_ar_entry(  # noqa: PLR0913, PLR0917
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,

--- a/custom_components/asusrouter/manifest.json
+++ b/custom_components/asusrouter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/jgassens/ha-asusrouter/issues",
   "loggers": ["asusrouter"],
   "requirements": [
-    "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
+    "asusrouter@git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
   ],
   "version": "1.0.0+jgassens.1"
 }

--- a/custom_components/asusrouter/manifest.json
+++ b/custom_components/asusrouter/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
   ],
-  "version": "1.0.0-jgassens.1"
+  "version": "1.0.0+jgassens.1"
 }

--- a/custom_components/asusrouter/manifest.json
+++ b/custom_components/asusrouter/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "asusrouter@git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
   ],
-  "version": "1.0.0+jgassens.1"
+  "version": "1.0.0+jgassens.2"
 }

--- a/custom_components/asusrouter/manifest.json
+++ b/custom_components/asusrouter/manifest.json
@@ -8,6 +8,8 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Vaskivskyi/ha-asusrouter/issues",
   "loggers": ["asusrouter"],
-  "requirements": ["asusrouter==2.0.0.dev0"],
+  "requirements": [
+    "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
+  ],
   "version": "1.0.0.dev0"
 }

--- a/custom_components/asusrouter/manifest.json
+++ b/custom_components/asusrouter/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "asusrouter",
-  "name": "AsusRouter",
-  "codeowners": ["@vaskivskyi"],
+  "name": "AsusRouter Static DHCP Fork",
+  "codeowners": ["@jgassens"],
   "config_flow": true,
-  "documentation": "https://asusrouter.vaskivskyi.com",
+  "documentation": "https://github.com/jgassens/ha-asusrouter#readme",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/Vaskivskyi/ha-asusrouter/issues",
+  "issue_tracker": "https://github.com/jgassens/ha-asusrouter/issues",
   "loggers": ["asusrouter"],
   "requirements": [
     "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a"
   ],
-  "version": "1.0.0.dev0"
+  "version": "1.0.0-jgassens.1"
 }

--- a/custom_components/asusrouter/router.py
+++ b/custom_components/asusrouter/router.py
@@ -743,7 +743,7 @@ class ARDevice:
         if new_node:
             async_dispatcher_send(self.hass, self.signal_aimesh_new)
 
-    async def update_pc_rules(self) -> None:
+    async def update_pc_rules(self) -> bool:
         """Update parental control rules."""
 
         _LOGGER.debug(
@@ -761,7 +761,7 @@ class ARDevice:
                     self._conf_host,
                     ex,
                 )
-            return
+            return False
 
         new_flag = False
 
@@ -796,6 +796,8 @@ class ARDevice:
         async_dispatcher_send(self.hass, self.signal_pc_rules_update)
         if new_flag:
             async_dispatcher_send(self.hass, self.signal_pc_rules_new)
+
+        return True
 
     @staticmethod
     def _static_dhcp_optional(value: Any) -> str:
@@ -1117,32 +1119,6 @@ class ARDevice:
 
     async def _init_services(self) -> None:
         """Initialize AsusRouter services."""
-
-        # Parental control service
-        async def async_service_device_internet_access(service: ServiceCall):
-            """Adjust device internet access."""
-
-            await self.bridge.async_pc_rule(raw=service.data)
-
-            # Force PC rules update
-            await self.update_pc_rules()
-
-            # In case of removing rule(s) we need to reload the platform
-            if service.data.get("state") == "remove":
-                unload = await self.hass.config_entries.async_unload_platforms(
-                    self._config_entry, [Platform.SWITCH]
-                )
-                if unload:
-                    await self.hass.config_entries.async_forward_entry_setups(
-                        self._config_entry, [Platform.SWITCH]
-                    )
-
-        if self._mode == ROUTER:
-            self.hass.services.async_register(
-                DOMAIN,
-                "device_internet_access",
-                async_service_device_internet_access,
-            )
 
         # Remove device trackers service
         async def async_service_remove_trackers(service: ServiceCall):

--- a/custom_components/asusrouter/router.py
+++ b/custom_components/asusrouter/router.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
+from ipaddress import IPv4Address
 import logging
 from typing import Any
 
@@ -27,7 +29,11 @@ from homeassistant.core import (
     ServiceCall,
     callback,
 )
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -73,8 +79,10 @@ from .const import (
     CONNECTED,
     COORDINATOR,
     DEVICES,
+    DNS,
     DOMAIN,
     FIRMWARE,
+    IP,
     LIST,
     MAC,
     MEDIA_BRIDGE,
@@ -85,7 +93,9 @@ from .const import (
     SENSORS,
     SENSORS_AIMESH,
     SENSORS_CONNECTED_DEVICES,
+    SENSORS_STATIC_DHCP,
     SSL,
+    STATIC_DHCP,
 )
 from .helpers import as_dict
 
@@ -327,6 +337,8 @@ class ARDevice:
             CONF_DEFAULT_CREATE_DEVICES,
         )
         self._pc_rules: dict[str, Any] = {}
+        self._static_dhcp_lock = asyncio.Lock()
+        self._static_dhcp_leases: list[dict[str, str]] = []
 
         # Client filter
         self._client_filter: str = self._options.get(
@@ -785,6 +797,324 @@ class ARDevice:
         if new_flag:
             async_dispatcher_send(self.hass, self.signal_pc_rules_new)
 
+    @staticmethod
+    def _static_dhcp_optional(value: Any) -> str:
+        """Return optional static DHCP values as strings."""
+
+        if value is None:
+            return ""
+        return str(value)
+
+    @staticmethod
+    def _static_dhcp_ip(value: Any) -> str:
+        """Normalize a static DHCP IPv4 address for comparisons."""
+
+        try:
+            return str(IPv4Address(str(value)))
+        except ValueError as ex:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_static_dhcp_ip",
+                translation_placeholders={"ip": str(value)},
+            ) from ex
+
+    @staticmethod
+    def _static_dhcp_mac(value: Any) -> str:
+        """Normalize a static DHCP MAC address for comparisons."""
+
+        try:
+            return format_mac(str(value))
+        except ValueError as ex:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_static_dhcp_mac",
+                translation_placeholders={"mac": str(value)},
+            ) from ex
+
+    def _static_dhcp_lease_to_dict(self, lease: Any) -> dict[str, str]:
+        """Convert a library static DHCP lease to HA attributes."""
+
+        return {
+            MAC: self._static_dhcp_mac(getattr(lease, MAC)),
+            IP: self._static_dhcp_optional(getattr(lease, IP)),
+            DNS: self._static_dhcp_optional(getattr(lease, DNS, "")),
+            "hostname": self._static_dhcp_optional(
+                getattr(lease, "hostname", "")
+            ),
+        }
+
+    def _static_dhcp_payload(
+        self,
+        leases: list[dict[str, str]],
+    ) -> dict[str, Any]:
+        """Compile static DHCP coordinator data."""
+
+        self._static_dhcp_leases = leases
+        return {
+            NUMBER: len(leases),
+            LIST: leases,
+        }
+
+    def _update_static_dhcp_data(
+        self,
+        leases: list[dict[str, str]],
+        update_coordinator: bool = False,
+    ) -> dict[str, Any]:
+        """Update static DHCP state and notify dependent entities."""
+
+        payload = self._static_dhcp_payload(leases)
+        if update_coordinator and STATIC_DHCP in self._sensor_coordinator:
+            coordinator = self._sensor_coordinator[STATIC_DHCP][COORDINATOR]
+            coordinator.async_set_updated_data(payload)
+
+        async_dispatcher_send(self.hass, self.signal_static_dhcp_update)
+        return payload
+
+    async def _async_read_static_dhcp_leases(
+        self,
+    ) -> list[dict[str, str]]:
+        """Read and cache static DHCP leases from the router."""
+
+        leases = await self.bridge.async_get_static_dhcp_leases()
+        return [self._static_dhcp_lease_to_dict(lease) for lease in leases]
+
+    async def async_get_static_dhcp_sensor_data(self) -> dict[str, Any]:
+        """Get static DHCP leases for the router-level sensor."""
+
+        if self._mode != ROUTER:
+            return self._static_dhcp_payload([])
+
+        async with self._static_dhcp_lock:
+            leases = await self._async_read_static_dhcp_leases()
+            return self._update_static_dhcp_data(leases)
+
+    def _check_static_dhcp_mode(self) -> None:
+        """Check whether static DHCP writes are allowed."""
+
+        if self._mode != ROUTER:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="static_dhcp_router_mode_required",
+            )
+
+    def static_dhcp_reservation(
+        self,
+        mac: str,
+    ) -> dict[str, str] | None:
+        """Return a static DHCP reservation for a MAC address."""
+
+        target_mac = self._static_dhcp_mac(mac)
+        for lease in self._static_dhcp_leases:
+            if lease[MAC] == target_mac:
+                return lease
+        return None
+
+    def static_dhcp_ip_conflict(
+        self,
+        mac: str,
+        ip: str,
+    ) -> dict[str, str] | None:
+        """Return a static DHCP reservation using this IP on another MAC."""
+
+        target_mac = self._static_dhcp_mac(mac)
+        target_ip = self._static_dhcp_ip(ip)
+        return self._find_static_dhcp_ip_conflict(
+            self._static_dhcp_leases,
+            target_mac,
+            target_ip,
+        )
+
+    def _find_static_dhcp_ip_conflict(
+        self,
+        leases: list[dict[str, str]],
+        mac: str,
+        ip: str,
+    ) -> dict[str, str] | None:
+        """Find a reservation with the requested IP on another MAC."""
+
+        for lease in leases:
+            if lease[MAC] != mac and lease[IP] == ip:
+                return lease
+        return None
+
+    async def _async_set_static_dhcp_lease_locked(
+        self,
+        mac: str,
+        ip: str,
+        hostname: str | None = None,
+        dns: str | None = None,
+        allow_existing_ip_change: bool = True,
+    ) -> dict[str, str]:
+        """Set a static DHCP lease while the write lock is held."""
+
+        expected_mac = self._static_dhcp_mac(mac)
+        expected_ip = self._static_dhcp_ip(ip)
+        expected_dns = self._static_dhcp_optional(dns)
+        if expected_dns:
+            expected_dns = self._static_dhcp_ip(expected_dns)
+        expected_hostname = self._static_dhcp_optional(hostname)
+
+        current_leases = await self._async_read_static_dhcp_leases()
+        existing = next(
+            (lease for lease in current_leases if lease[MAC] == expected_mac),
+            None,
+        )
+
+        if (
+            existing is not None
+            and existing[IP] != expected_ip
+            and not allow_existing_ip_change
+        ):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="static_dhcp_existing_reservation",
+                translation_placeholders={
+                    "mac": expected_mac,
+                    "ip": existing[IP],
+                },
+            )
+
+        ip_conflict = self._find_static_dhcp_ip_conflict(
+            current_leases,
+            expected_mac,
+            expected_ip,
+        )
+        if ip_conflict is not None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="static_dhcp_duplicate_ip",
+                translation_placeholders={
+                    "ip": expected_ip,
+                    "mac": ip_conflict[MAC],
+                },
+            )
+
+        if (
+            existing is not None
+            and existing[IP] == expected_ip
+            and not allow_existing_ip_change
+        ):
+            self._update_static_dhcp_data(
+                current_leases,
+                update_coordinator=True,
+            )
+            return existing
+
+        try:
+            await self.bridge.async_set_static_dhcp_lease(
+                mac=expected_mac,
+                ip=expected_ip,
+                hostname=expected_hostname,
+                dns=expected_dns,
+            )
+            leases = await self._async_read_static_dhcp_leases()
+        except ValueError as ex:
+            raise ServiceValidationError(str(ex)) from ex
+        except (AsusRouterError, UpdateFailed, OSError) as ex:
+            raise HomeAssistantError(
+                f"Unable to set static DHCP lease: {ex}"
+            ) from ex
+
+        self._update_static_dhcp_data(
+            leases,
+            update_coordinator=True,
+        )
+        verified = next(
+            (
+                lease
+                for lease in leases
+                if lease[MAC] == expected_mac
+                and lease[IP] == expected_ip
+                and lease[DNS] == expected_dns
+                and lease["hostname"] == expected_hostname
+            ),
+            None,
+        )
+        if verified is None:
+            raise HomeAssistantError(
+                "Static DHCP lease did not match after router apply"
+            )
+
+        return verified
+
+    async def async_set_static_dhcp_lease(
+        self,
+        mac: str,
+        ip: str,
+        hostname: str | None = None,
+        dns: str | None = None,
+    ) -> dict[str, str]:
+        """Set or replace a static DHCP lease."""
+
+        self._check_static_dhcp_mode()
+        async with self._static_dhcp_lock:
+            return await self._async_set_static_dhcp_lease_locked(
+                mac=mac,
+                ip=ip,
+                hostname=hostname,
+                dns=dns,
+                allow_existing_ip_change=True,
+            )
+
+    async def async_reserve_current_ip(
+        self,
+        mac: str,
+        ip: str,
+        hostname: str | None = None,
+    ) -> dict[str, str]:
+        """Reserve a client's current IP without moving existing leases."""
+
+        self._check_static_dhcp_mode()
+        async with self._static_dhcp_lock:
+            return await self._async_set_static_dhcp_lease_locked(
+                mac=mac,
+                ip=ip,
+                hostname=hostname,
+                allow_existing_ip_change=False,
+            )
+
+    async def async_remove_static_dhcp_lease(
+        self,
+        mac: str,
+    ) -> None:
+        """Remove a static DHCP lease and verify it is gone."""
+
+        self._check_static_dhcp_mode()
+        expected_mac = self._static_dhcp_mac(mac)
+
+        async with self._static_dhcp_lock:
+            try:
+                await self.bridge.async_remove_static_dhcp_lease(
+                    expected_mac,
+                    apply=True,
+                )
+                leases = await self._async_read_static_dhcp_leases()
+            except ValueError as ex:
+                raise ServiceValidationError(str(ex)) from ex
+            except (AsusRouterError, UpdateFailed, OSError) as ex:
+                raise HomeAssistantError(
+                    f"Unable to remove static DHCP lease: {ex}"
+                ) from ex
+
+            payload = self._update_static_dhcp_data(
+                leases,
+                update_coordinator=True,
+            )
+            if any(lease[MAC] == expected_mac for lease in payload[LIST]):
+                raise HomeAssistantError(
+                    "Static DHCP lease still exists after router apply"
+                )
+
+    async def async_refresh_static_dhcp_leases(self) -> None:
+        """Refresh static DHCP leases."""
+
+        if self._mode != ROUTER:
+            return
+
+        async with self._static_dhcp_lock:
+            leases = await self._async_read_static_dhcp_leases()
+            self._update_static_dhcp_data(leases, update_coordinator=True)
+
     async def _init_services(self) -> None:
         """Initialize AsusRouter services."""
 
@@ -856,6 +1186,11 @@ class ARDevice:
         if self._mode in (ACCESS_POINT, MEDIA_BRIDGE, ROUTER):
             available_sensors[DEVICES] = {SENSORS: SENSORS_CONNECTED_DEVICES}
             available_sensors[AIMESH] = {SENSORS: SENSORS_AIMESH}
+        if self._mode == ROUTER:
+            available_sensors[STATIC_DHCP] = {
+                SENSORS: SENSORS_STATIC_DHCP,
+                METHOD: self.async_get_static_dhcp_sensor_data,
+            }
 
         # Process available sensors
         for sensor_type, sensor_definition in available_sensors.items():
@@ -1068,6 +1403,12 @@ class ARDevice:
         return f"{DOMAIN}-pc-rules-update"
 
     @property
+    def signal_static_dhcp_update(self) -> str:
+        """Notify updated static DHCP leases."""
+
+        return f"{DOMAIN}-static-dhcp-update"
+
+    @property
     def aimesh(self) -> dict[str, Any]:
         """Return AiMesh nodes."""
 
@@ -1086,10 +1427,22 @@ class ARDevice:
         return self._mac
 
     @property
+    def mode(self) -> str:
+        """Router operation mode."""
+
+        return self._mode
+
+    @property
     def pc_rules(self) -> dict[str, ParentalControlRule]:
         """Return parental control rules."""
 
         return self._pc_rules
+
+    @property
+    def static_dhcp_leases(self) -> list[dict[str, str]]:
+        """Return cached static DHCP leases."""
+
+        return self._static_dhcp_leases
 
     @property
     def sensor_coordinator(self) -> dict[str, Any]:

--- a/custom_components/asusrouter/services.py
+++ b/custom_components/asusrouter/services.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, cast
 
 from asusrouter.error import AsusRouterError
+from asusrouter.modules.parental_control import PCRuleType
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -19,6 +20,7 @@ import voluptuous as vol
 
 from .client import ARClient
 from .const import ASUSROUTER, DOMAIN, IP, MAC, ROUTER
+from .helpers import to_unique_id
 from .router import ARDevice
 
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
@@ -286,8 +288,39 @@ def _direct_device_router(
     return routers[0]
 
 
-async def _reload_parental_control_switches(router: ARDevice) -> None:
-    """Reload parental-control switches after removing rules."""
+def _internet_access_state_matches(
+    router: ARDevice,
+    state: str,
+    devices: list[dict[str, Any]],
+) -> bool:
+    """Return whether the refreshed rules match the requested state."""
+
+    rules_by_mac = {
+        router._static_dhcp_mac(rule.mac): rule
+        for rule in router.pc_rules.values()
+        if rule.mac is not None
+    }
+    target_macs = {router._static_dhcp_mac(device[MAC]) for device in devices}
+
+    if state == "remove":
+        return target_macs.isdisjoint(rules_by_mac)
+
+    expected_type = {
+        "allow": PCRuleType.DISABLE,
+        "block": PCRuleType.BLOCK,
+    }.get(state)
+    return expected_type is not None and all(
+        (rule := rules_by_mac.get(mac)) is not None
+        and rule.type == expected_type
+        for mac in target_macs
+    )
+
+
+async def _reload_parental_control_switches(
+    router: ARDevice,
+    removed_devices: list[dict[str, Any]],
+) -> None:
+    """Remove stale rule entities and reload parental-control switches."""
 
     unload = await router.hass.config_entries.async_unload_platforms(
         router._config_entry, [Platform.SWITCH]
@@ -296,6 +329,25 @@ async def _reload_parental_control_switches(router: ARDevice) -> None:
         raise HomeAssistantError(
             "Unable to reload AsusRouter parental-control switches"
         )
+
+    removed_unique_ids = {
+        to_unique_id(
+            f"{router.mac}_{router._static_dhcp_mac(device[MAC])}"
+            "_block_internet"
+        )
+        for device in removed_devices
+    }
+    registry = er.async_get(router.hass)
+    for entry in er.async_entries_for_config_entry(
+        registry, router._config_entry.entry_id
+    ):
+        if (
+            entry.domain == Platform.SWITCH
+            and entry.platform == DOMAIN
+            and entry.unique_id in removed_unique_ids
+        ):
+            registry.async_remove(entry.entity_id)
+
     await router.hass.config_entries.async_forward_entry_setups(
         router._config_entry, [Platform.SWITCH]
     )
@@ -396,7 +448,7 @@ async def _async_device_internet_access(
 
     for router, devices in router_devices.items():
         try:
-            applied = await router.bridge.async_pc_rule(
+            await router.bridge.async_pc_rule(
                 state=call.data[ATTR_STATE],
                 devices=devices,
             )
@@ -406,14 +458,15 @@ async def _async_device_internet_access(
             ) from ex
 
         refreshed = await router.update_pc_rules()
-        if not applied or not refreshed:
+        if not refreshed or not _internet_access_state_matches(
+            router, call.data[ATTR_STATE], devices
+        ):
             raise HomeAssistantError(
-                "The router did not accept the internet-access change "
-                "or the integration could not refresh its state"
+                "The router's internet-access state could not be confirmed"
             )
 
         if call.data[ATTR_STATE] == "remove":
-            await _reload_parental_control_switches(router)
+            await _reload_parental_control_switches(router, devices)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:

--- a/custom_components/asusrouter/services.py
+++ b/custom_components/asusrouter/services.py
@@ -1,0 +1,323 @@
+"""AsusRouter service actions."""
+
+from __future__ import annotations
+
+from ipaddress import IPv4Address
+import re
+from typing import Any, cast
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_registry as er,
+    target as target_helpers,
+)
+import voluptuous as vol
+
+from .client import ARClient
+from .const import ASUSROUTER, DOMAIN, IP, MAC, ROUTER
+from .router import ARDevice
+
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_DNS = "dns"
+ATTR_ENTITIES = "entities"
+ATTR_HOSTNAME = "hostname"
+
+SERVICE_REFRESH_STATIC_DHCP_LEASES = "refresh_static_dhcp_leases"
+SERVICE_REMOVE_STATIC_DHCP_LEASE = "remove_static_dhcp_lease"
+SERVICE_RESERVE_CURRENT_IP = "reserve_current_ip"
+SERVICE_SET_STATIC_DHCP_LEASE = "set_static_dhcp_lease"
+
+MAC_ADDRESS = re.compile(
+    r"^(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$|^[0-9A-Fa-f]{12}$"
+)
+
+
+def _strip(value: Any) -> str:
+    """Return a stripped string."""
+
+    stripped = str(value).strip()
+    if not stripped:
+        raise vol.Invalid("value is required")
+    return stripped
+
+
+def _mac_address(value: Any) -> str:
+    """Validate a MAC address."""
+
+    normalized = _strip(value)
+    if not MAC_ADDRESS.match(normalized):
+        raise vol.Invalid("expected MAC address")
+    return normalized
+
+
+def _ipv4_address(value: Any) -> str:
+    """Validate an IPv4 address."""
+
+    value = _strip(value)
+    try:
+        return str(IPv4Address(value))
+    except ValueError as ex:
+        raise vol.Invalid("expected IPv4 address") from ex
+
+
+def _optional_string(value: Any) -> str:
+    """Return an optional stripped string."""
+
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _optional_ipv4_address(value: Any) -> str:
+    """Validate an optional IPv4 address."""
+
+    value = _optional_string(value)
+    if not value:
+        return ""
+    return _ipv4_address(value)
+
+
+def _entity_ids(value: Any) -> list[str]:
+    """Normalize one or more entity IDs."""
+
+    return cv.entity_ids(value)
+
+
+def _reserve_schema(value: dict[str, Any]) -> dict[str, Any]:
+    """Validate reserve_current_ip fields."""
+
+    if not any(
+        field in value
+        for field in (
+            ATTR_ENTITY_ID,
+            "device_id",
+            "area_id",
+            "floor_id",
+            "label_id",
+            ATTR_ENTITIES,
+        )
+    ):
+        raise vol.Invalid("target is required")
+    return value
+
+
+SET_STATIC_DHCP_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Required(MAC): _mac_address,
+        vol.Required(IP): _ipv4_address,
+        vol.Optional(ATTR_HOSTNAME): _optional_string,
+        vol.Optional(ATTR_DNS): _optional_ipv4_address,
+    }
+)
+
+REMOVE_STATIC_DHCP_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Required(MAC): _mac_address,
+    }
+)
+
+REFRESH_STATIC_DHCP_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+    }
+)
+
+RESERVE_CURRENT_IP_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            **cv.TARGET_SERVICE_FIELDS,
+            vol.Optional(ATTR_ENTITIES): _entity_ids,
+        },
+        _reserve_schema,
+    )
+)
+
+
+def _get_router(hass: HomeAssistant, config_entry_id: str) -> ARDevice:
+    """Get a loaded AsusRouter instance by config entry ID."""
+
+    router_data = hass.data.get(DOMAIN, {}).get(config_entry_id)
+    if not router_data or ASUSROUTER not in router_data:
+        raise HomeAssistantError(
+            f"AsusRouter config entry is not loaded: {config_entry_id}"
+        )
+
+    router: ARDevice = router_data[ASUSROUTER]
+    return router
+
+
+def _require_router_mode(router: ARDevice) -> None:
+    """Require a router-mode entry."""
+
+    if router.mode != ROUTER:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="static_dhcp_router_mode_required",
+        )
+
+
+def _get_entity_ids(hass: HomeAssistant, call: ServiceCall) -> list[str]:
+    """Return service target entity IDs."""
+
+    selected = target_helpers.async_extract_referenced_entity_ids(
+        hass,
+        target_helpers.TargetSelection(call.data),
+    )
+    entity_ids = set(selected.referenced)
+    registry = er.async_get(hass)
+    entity_ids.update(
+        entity_id
+        for entity_id in selected.indirectly_referenced
+        if (entry := registry.async_get(entity_id)) is not None
+        and entry.domain == "device_tracker"
+        and entry.platform == DOMAIN
+    )
+
+    legacy_entities = call.data.get(ATTR_ENTITIES, [])
+    entity_ids.update(legacy_entities)
+
+    return sorted(entity_ids)
+
+
+def _get_client_field(
+    router: ARDevice,
+    mac: str,
+    field: str,
+) -> str | None:
+    """Get a field from the router client cache."""
+
+    client = cast(
+        ARClient | None, router.devices.get(router._static_dhcp_mac(mac))
+    )
+    if client is None:
+        return None
+
+    match field:
+        case "ip":
+            return client.ip_address
+        case "name":
+            return client.name
+        case _:
+            return None
+
+
+def _client_entity_data(
+    hass: HomeAssistant,
+    entity_id: str,
+) -> tuple[ARDevice, str, str, str | None]:
+    """Get router, MAC, current IP, and hostname from a device tracker."""
+
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    if entry is None:
+        raise ServiceValidationError(f"Entity not found: {entity_id}")
+    if entry.config_entry_id is None:
+        raise ServiceValidationError(
+            f"Entity is not tied to a config entry: {entity_id}"
+        )
+
+    router = _get_router(hass, entry.config_entry_id)
+    _require_router_mode(router)
+
+    capabilities = entry.capabilities or {}
+    mac = capabilities.get(MAC)
+    if mac is None:
+        state = hass.states.get(entity_id)
+        mac = state.attributes.get(MAC) if state is not None else None
+    if mac is None:
+        raise ServiceValidationError(
+            f"Device tracker has no MAC address: {entity_id}"
+        )
+
+    state = hass.states.get(entity_id)
+    ip = _get_client_field(router, mac, "ip")
+    if ip is None and state is not None:
+        ip = state.attributes.get(IP) or state.attributes.get("ip_address")
+    if ip is None:
+        raise ServiceValidationError(
+            f"Device tracker has no current IP address: {entity_id}"
+        )
+
+    hostname = _get_client_field(router, mac, "name")
+    if hostname is None:
+        hostname = capabilities.get("name")
+    if hostname is None and state is not None:
+        hostname = state.attributes.get("host_name") or state.attributes.get(
+            "friendly_name"
+        )
+
+    return router, mac, ip, hostname
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up AsusRouter service actions."""
+
+    async def async_set_static_dhcp_lease(call: ServiceCall) -> None:
+        """Set a static DHCP lease."""
+
+        router = _get_router(hass, call.data[ATTR_CONFIG_ENTRY_ID])
+        _require_router_mode(router)
+        await router.async_set_static_dhcp_lease(
+            mac=call.data[MAC],
+            ip=call.data[IP],
+            hostname=call.data.get(ATTR_HOSTNAME),
+            dns=call.data.get(ATTR_DNS),
+        )
+
+    async def async_remove_static_dhcp_lease(call: ServiceCall) -> None:
+        """Remove a static DHCP lease."""
+
+        router = _get_router(hass, call.data[ATTR_CONFIG_ENTRY_ID])
+        _require_router_mode(router)
+        await router.async_remove_static_dhcp_lease(call.data[MAC])
+
+    async def async_reserve_current_ip(call: ServiceCall) -> None:
+        """Reserve the current IP for one or more device trackers."""
+
+        for entity_id in _get_entity_ids(hass, call):
+            router, mac, ip, hostname = _client_entity_data(hass, entity_id)
+            await router.async_reserve_current_ip(
+                mac=mac,
+                ip=ip,
+                hostname=hostname,
+            )
+
+    async def async_refresh_static_dhcp_leases(call: ServiceCall) -> None:
+        """Refresh static DHCP leases."""
+
+        router = _get_router(hass, call.data[ATTR_CONFIG_ENTRY_ID])
+        _require_router_mode(router)
+        await router.async_refresh_static_dhcp_leases()
+
+    if hass.services.has_service(DOMAIN, SERVICE_SET_STATIC_DHCP_LEASE):
+        return
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_STATIC_DHCP_LEASE,
+        async_set_static_dhcp_lease,
+        schema=SET_STATIC_DHCP_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REMOVE_STATIC_DHCP_LEASE,
+        async_remove_static_dhcp_lease,
+        schema=REMOVE_STATIC_DHCP_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RESERVE_CURRENT_IP,
+        async_reserve_current_ip,
+        schema=RESERVE_CURRENT_IP_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH_STATIC_DHCP_LEASES,
+        async_refresh_static_dhcp_leases,
+        schema=REFRESH_STATIC_DHCP_SCHEMA,
+    )

--- a/custom_components/asusrouter/services.py
+++ b/custom_components/asusrouter/services.py
@@ -6,7 +6,8 @@ from ipaddress import IPv4Address
 import re
 from typing import Any, cast
 
-from homeassistant.const import ATTR_ENTITY_ID
+from asusrouter.error import AsusRouterError
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import (
@@ -21,10 +22,14 @@ from .const import ASUSROUTER, DOMAIN, IP, MAC, ROUTER
 from .router import ARDevice
 
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_DEVICES = "devices"
 ATTR_DNS = "dns"
 ATTR_ENTITIES = "entities"
 ATTR_HOSTNAME = "hostname"
+ATTR_NAME = "name"
+ATTR_STATE = "state"
 
+SERVICE_DEVICE_INTERNET_ACCESS = "device_internet_access"
 SERVICE_REFRESH_STATIC_DHCP_LEASES = "refresh_static_dhcp_leases"
 SERVICE_REMOVE_STATIC_DHCP_LEASE = "remove_static_dhcp_lease"
 SERVICE_RESERVE_CURRENT_IP = "reserve_current_ip"
@@ -104,6 +109,14 @@ def _reserve_schema(value: dict[str, Any]) -> dict[str, Any]:
     return value
 
 
+def _internet_access_schema(value: dict[str, Any]) -> dict[str, Any]:
+    """Require a Home Assistant target or a direct device list."""
+
+    if value.get(ATTR_DEVICES):
+        return value
+    return _reserve_schema(value)
+
+
 SET_STATIC_DHCP_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
@@ -134,6 +147,27 @@ RESERVE_CURRENT_IP_SCHEMA = vol.Schema(
             vol.Optional(ATTR_ENTITIES): _entity_ids,
         },
         _reserve_schema,
+    )
+)
+
+
+DEVICE_INTERNET_ACCESS_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            **cv.TARGET_SERVICE_FIELDS,
+            vol.Optional(ATTR_ENTITIES): _entity_ids,
+            vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
+            vol.Optional(ATTR_DEVICES): [
+                vol.Schema(
+                    {
+                        vol.Required(MAC): _mac_address,
+                        vol.Optional(ATTR_NAME): _optional_string,
+                    }
+                )
+            ],
+            vol.Required(ATTR_STATE): vol.In(("allow", "block", "remove")),
+        },
+        _internet_access_schema,
     )
 )
 
@@ -182,6 +216,89 @@ def _get_entity_ids(hass: HomeAssistant, call: ServiceCall) -> list[str]:
     entity_ids.update(legacy_entities)
 
     return sorted(entity_ids)
+
+
+def _internet_access_entity_data(
+    hass: HomeAssistant,
+    entity_id: str,
+) -> tuple[ARDevice, dict[str, str]]:
+    """Get router and parental-control data from a device tracker."""
+
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    if entry is None:
+        raise ServiceValidationError(f"Entity not found: {entity_id}")
+    if entry.domain != "device_tracker" or entry.platform != DOMAIN:
+        raise ServiceValidationError(
+            f"Entity is not an AsusRouter device tracker: {entity_id}"
+        )
+    if entry.config_entry_id is None:
+        raise ServiceValidationError(
+            f"Entity is not tied to a config entry: {entity_id}"
+        )
+
+    router = _get_router(hass, entry.config_entry_id)
+    _require_router_mode(router)
+
+    capabilities = entry.capabilities or {}
+    state = hass.states.get(entity_id)
+    mac = capabilities.get(MAC)
+    if mac is None and state is not None:
+        mac = state.attributes.get(MAC)
+    if mac is None:
+        raise ServiceValidationError(
+            f"Device tracker has no MAC address: {entity_id}"
+        )
+
+    mac = router._static_dhcp_mac(mac)
+    name = _get_client_field(router, mac, ATTR_NAME)
+    if name is None:
+        name = capabilities.get(ATTR_NAME)
+    if name is None and state is not None:
+        name = state.attributes.get("host_name") or state.attributes.get(
+            "friendly_name"
+        )
+
+    return router, {MAC: mac, ATTR_NAME: _optional_string(name)}
+
+
+def _direct_device_router(
+    hass: HomeAssistant,
+    config_entry_id: str | None,
+) -> ARDevice:
+    """Resolve the router for direct MAC-address targets."""
+
+    if config_entry_id:
+        router = _get_router(hass, config_entry_id)
+        _require_router_mode(router)
+        return router
+
+    routers = [
+        data[ASUSROUTER]
+        for data in hass.data.get(DOMAIN, {}).values()
+        if ASUSROUTER in data and data[ASUSROUTER].mode == ROUTER
+    ]
+    if len(routers) != 1:
+        raise ServiceValidationError(
+            "config_entry_id is required when Home Assistant does not have "
+            "exactly one loaded AsusRouter router-mode entry"
+        )
+    return routers[0]
+
+
+async def _reload_parental_control_switches(router: ARDevice) -> None:
+    """Reload parental-control switches after removing rules."""
+
+    unload = await router.hass.config_entries.async_unload_platforms(
+        router._config_entry, [Platform.SWITCH]
+    )
+    if not unload:
+        raise HomeAssistantError(
+            "Unable to reload AsusRouter parental-control switches"
+        )
+    await router.hass.config_entries.async_forward_entry_setups(
+        router._config_entry, [Platform.SWITCH]
+    )
 
 
 def _get_client_field(
@@ -254,8 +371,58 @@ def _client_entity_data(
     return router, mac, ip, hostname
 
 
+async def _async_device_internet_access(
+    hass: HomeAssistant,
+    call: ServiceCall,
+) -> None:
+    """Change internet access for one or more router clients."""
+
+    router_devices: dict[ARDevice, list[dict[str, str]]] = {}
+    for entity_id in _get_entity_ids(hass, call):
+        router, device = _internet_access_entity_data(hass, entity_id)
+        router_devices.setdefault(router, []).append(device)
+
+    direct_devices = call.data.get(ATTR_DEVICES, [])
+    if direct_devices:
+        router = _direct_device_router(
+            hass, call.data.get(ATTR_CONFIG_ENTRY_ID)
+        )
+        router_devices.setdefault(router, []).extend(direct_devices)
+
+    if not router_devices:
+        raise ServiceValidationError(
+            "At least one AsusRouter device tracker or device is required"
+        )
+
+    for router, devices in router_devices.items():
+        try:
+            applied = await router.bridge.async_pc_rule(
+                state=call.data[ATTR_STATE],
+                devices=devices,
+            )
+        except (AsusRouterError, OSError) as ex:
+            raise HomeAssistantError(
+                f"Unable to change device internet access: {ex}"
+            ) from ex
+
+        refreshed = await router.update_pc_rules()
+        if not applied or not refreshed:
+            raise HomeAssistantError(
+                "The router did not accept the internet-access change "
+                "or the integration could not refresh its state"
+            )
+
+        if call.data[ATTR_STATE] == "remove":
+            await _reload_parental_control_switches(router)
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Set up AsusRouter service actions."""
+
+    async def async_device_internet_access(call: ServiceCall) -> None:
+        """Change internet access for one or more router clients."""
+
+        await _async_device_internet_access(hass, call)
 
     async def async_set_static_dhcp_lease(call: ServiceCall) -> None:
         """Set a static DHCP lease."""
@@ -297,6 +464,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     if hass.services.has_service(DOMAIN, SERVICE_SET_STATIC_DHCP_LEASE):
         return
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DEVICE_INTERNET_ACCESS,
+        async_device_internet_access,
+        schema=DEVICE_INTERNET_ACCESS_SCHEMA,
+    )
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_STATIC_DHCP_LEASE,

--- a/custom_components/asusrouter/services.yaml
+++ b/custom_components/asusrouter/services.yaml
@@ -30,3 +30,49 @@ remove_trackers:
           integration: asusrouter
           domain: device_tracker
           multiple: true
+set_static_dhcp_lease:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: asusrouter
+    mac:
+      required: true
+      selector:
+        text:
+    ip:
+      required: true
+      selector:
+        text:
+    hostname:
+      required: false
+      selector:
+        text:
+    dns:
+      required: false
+      selector:
+        text:
+remove_static_dhcp_lease:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: asusrouter
+    mac:
+      required: true
+      selector:
+        text:
+reserve_current_ip:
+  target:
+    entity:
+      integration: asusrouter
+      domain: device_tracker
+refresh_static_dhcp_leases:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: asusrouter

--- a/custom_components/asusrouter/services.yaml
+++ b/custom_components/asusrouter/services.yaml
@@ -1,12 +1,9 @@
 device_internet_access:
+  target:
+    entity:
+      integration: asusrouter
+      domain: device_tracker
   fields:
-    entities:
-      required: false
-      selector:
-        entity:
-          integration: asusrouter
-          domain: device_tracker
-          multiple: true
     state:
       required: true
       selector:

--- a/custom_components/asusrouter/strings.json
+++ b/custom_components/asusrouter/strings.json
@@ -255,6 +255,77 @@
           "description": "Select device(s) to remove from the device registry"
         }
       }
+    },
+    "set_static_dhcp_lease": {
+      "name": "Set static DHCP lease",
+      "description": "Create or update a static DHCP reservation on the selected router.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Router",
+          "description": "The AsusRouter config entry to change."
+        },
+        "mac": {
+          "name": "MAC address",
+          "description": "The client MAC address to reserve."
+        },
+        "ip": {
+          "name": "IP address",
+          "description": "The IPv4 address to reserve for the client."
+        },
+        "hostname": {
+          "name": "Hostname",
+          "description": "Optional hostname to store with the reservation."
+        },
+        "dns": {
+          "name": "DNS",
+          "description": "Optional DNS IPv4 address to store with the reservation."
+        }
+      }
+    },
+    "remove_static_dhcp_lease": {
+      "name": "Remove static DHCP lease",
+      "description": "Remove a static DHCP reservation from the selected router.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Router",
+          "description": "The AsusRouter config entry to change."
+        },
+        "mac": {
+          "name": "MAC address",
+          "description": "The client MAC address to remove from reservations."
+        }
+      }
+    },
+    "reserve_current_ip": {
+      "name": "Reserve current IP",
+      "description": "Reserve the current IP address for selected AsusRouter device trackers."
+    },
+    "refresh_static_dhcp_leases": {
+      "name": "Refresh static DHCP leases",
+      "description": "Refresh the router static DHCP reservation sensor.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Router",
+          "description": "The AsusRouter config entry to refresh."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "invalid_static_dhcp_ip": {
+      "message": "Invalid static DHCP IPv4 address: {ip}"
+    },
+    "invalid_static_dhcp_mac": {
+      "message": "Invalid static DHCP MAC address: {mac}"
+    },
+    "static_dhcp_duplicate_ip": {
+      "message": "IP address {ip} is already reserved for {mac}."
+    },
+    "static_dhcp_existing_reservation": {
+      "message": "{mac} is already reserved to {ip}. Use set_static_dhcp_lease to change it."
+    },
+    "static_dhcp_router_mode_required": {
+      "message": "Static DHCP leases can only be changed in router mode."
     }
   },
   "selector": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "AsusRouter",
+  "name": "AsusRouter Static DHCP Fork",
   "content_in_root": false,
-  "homeassistant": "2025.3.0"
+  "homeassistant": "2026.7.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers     = [
 ]
 dependencies    = [
     # The integration still uses the legacy API removed from current AsusRouter dev.
-    "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a",
+    "asusrouter@git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a",
     "homeassistant==2026.7.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ split-on-trailing-comma = false
     "S105",    # Possible hardcoded password assigned to: "{}"
     "S106",    # Possible hardcoded password assigned to argument: "{}"
     "PLR0913", # Too many arguments in function definition ({c_args} > {max_args})
+    "PLR0917", # Too many positional arguments in function definition
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "ha-asusrouter"
-version         = "1.0.0.dev0"
+version         = "1.0.0-jgassens.1"
 license         = "Apache-2.0"
 requires-python = ">=3.14.2"
 readme          = "README.md"
@@ -22,9 +22,9 @@ dependencies    = [
 ]
 
 [project.urls]
-"Homepage"      = "https://asusrouter.vaskivskyi.com/"
-"Source Code"   = "https://github.com/Vaskivskyi/ha-asusrouter"
-"Bug Reports"   = "https://github.com/Vaskivskyi/ha-asusrouter/issues"
+"Homepage"      = "https://github.com/jgassens/ha-asusrouter"
+"Source Code"   = "https://github.com/jgassens/ha-asusrouter"
+"Bug Reports"   = "https://github.com/jgassens/ha-asusrouter/issues"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "ha-asusrouter"
-version         = "1.0.0-jgassens.1"
+version         = "1.0.0+jgassens.1"
 license         = "Apache-2.0"
 requires-python = ">=3.14.2"
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "ha-asusrouter"
-version         = "1.0.0+jgassens.1"
+version         = "1.0.0+jgassens.2"
 license         = "Apache-2.0"
 requires-python = ">=3.14.2"
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers     = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies    = [
-    "asusrouter==1.21.3",
+    # The integration still uses the legacy API removed from current AsusRouter dev.
+    "asusrouter @ git+https://github.com/jgassens/asusrouter.git@0d471818f60c588b78625bed50b45c7162be5e3a",
     "homeassistant==2026.7.4",
 ]
 

--- a/tests/test_device_internet_access.py
+++ b/tests/test_device_internet_access.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock, patch
 
-from asusrouter.modules.parental_control import PCRuleType
+from asusrouter.modules.parental_control import ParentalControlRule, PCRuleType
+from homeassistant.const import Platform
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import pytest
 import voluptuous as vol
@@ -14,6 +15,7 @@ from custom_components.asusrouter.const import ASUSROUTER, DOMAIN, ROUTER
 from custom_components.asusrouter.services import (
     DEVICE_INTERNET_ACCESS_SCHEMA,
     SERVICE_DEVICE_INTERNET_ACCESS,
+    _reload_parental_control_switches,
     async_setup_services,
 )
 
@@ -107,7 +109,27 @@ def _router() -> Mock:
 
     router = Mock()
     router.mode = ROUTER
-    router.bridge.async_pc_rule = AsyncMock(return_value=True)
+    router.mac = "24:4b:fe:f5:ee:20"
+    router.pc_rules = {}
+    router._static_dhcp_mac.side_effect = lambda mac: str(mac).lower()
+
+    async def apply_rule(*, state: str, devices: list[dict[str, str]]) -> bool:
+        for device in devices:
+            mac = str(device["mac"]).lower()
+            if state == "remove":
+                router.pc_rules.pop(mac, None)
+                continue
+            router.pc_rules[mac] = ParentalControlRule(
+                mac=mac,
+                name=device.get("name", ""),
+                type={
+                    "allow": PCRuleType.DISABLE,
+                    "block": PCRuleType.BLOCK,
+                }[state],
+            )
+        return True
+
+    router.bridge.async_pc_rule = AsyncMock(side_effect=apply_rule)
     router.update_pc_rules = AsyncMock(return_value=True)
     return router
 
@@ -206,10 +228,12 @@ async def test_direct_devices_require_router_for_multiple_entries() -> None:
 
 
 @pytest.mark.asyncio
-async def test_remove_reloads_parental_control_switches() -> None:
-    """Removing a rule should reload switch entities after confirmation."""
+async def test_confirmed_idempotent_remove_reloads_switches() -> None:
+    """An already-removed rule should still clean up switch entities."""
 
     router = _router()
+    router.bridge.async_pc_rule.side_effect = None
+    router.bridge.async_pc_rule.return_value = False
     hass, handlers = _service_hass(router)
     await async_setup_services(hass)
     handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
@@ -234,7 +258,51 @@ async def test_remove_reloads_parental_control_switches() -> None:
     ):
         await handler(call)
 
-    reload_switches.assert_awaited_once_with(router)
+    reload_switches.assert_awaited_once_with(router, call.data["devices"])
+
+
+@pytest.mark.asyncio
+async def test_remove_deletes_matching_switch_registry_entry() -> None:
+    """Removing a rule should not leave an unavailable GUI entity."""
+
+    router = _router()
+    router._config_entry = Mock(entry_id="router-1")
+    router.hass.config_entries.async_unload_platforms = AsyncMock(
+        return_value=True
+    )
+    router.hass.config_entries.async_forward_entry_setups = AsyncMock()
+    registry = Mock()
+    matching = Mock(
+        domain=Platform.SWITCH,
+        platform=DOMAIN,
+        unique_id=("24:4b:fe:f5:ee:20_aa:bb:cc:dd:ee:ff_block_internet"),
+        entity_id="switch.console_block_internet",
+    )
+    unrelated = Mock(
+        domain=Platform.SWITCH,
+        platform=DOMAIN,
+        unique_id="24:4b:fe:f5:ee:20_block_internet",
+        entity_id="switch.router_block_internet",
+    )
+
+    with (
+        patch(
+            "custom_components.asusrouter.services.er.async_get",
+            return_value=registry,
+        ),
+        patch(
+            "custom_components.asusrouter.services.er."
+            "async_entries_for_config_entry",
+            return_value=[matching, unrelated],
+        ),
+    ):
+        await _reload_parental_control_switches(
+            router, [{"mac": "AA:BB:CC:DD:EE:FF"}]
+        )
+
+    registry.async_remove.assert_called_once_with(
+        "switch.console_block_internet"
+    )
 
 
 @pytest.mark.asyncio
@@ -242,6 +310,7 @@ async def test_service_surfaces_unconfirmed_router_write() -> None:
     """A failed router write must become a visible Home Assistant error."""
 
     router = _router()
+    router.bridge.async_pc_rule.side_effect = None
     router.bridge.async_pc_rule.return_value = False
     hass, handlers = _service_hass(router)
     await async_setup_services(hass)
@@ -259,6 +328,6 @@ async def test_service_surfaces_unconfirmed_router_write() -> None:
             "custom_components.asusrouter.services._get_entity_ids",
             return_value=[],
         ),
-        pytest.raises(HomeAssistantError, match="did not accept"),
+        pytest.raises(HomeAssistantError, match="could not be confirmed"),
     ):
         await handler(call)

--- a/tests/test_device_internet_access.py
+++ b/tests/test_device_internet_access.py
@@ -1,0 +1,264 @@
+"""Tests for device internet-access control."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from asusrouter.modules.parental_control import PCRuleType
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import pytest
+import voluptuous as vol
+
+from custom_components.asusrouter.bridge import ARBridge
+from custom_components.asusrouter.const import ASUSROUTER, DOMAIN, ROUTER
+from custom_components.asusrouter.services import (
+    DEVICE_INTERNET_ACCESS_SCHEMA,
+    SERVICE_DEVICE_INTERNET_ACCESS,
+    async_setup_services,
+)
+
+
+def _bridge(*results: bool) -> ARBridge:
+    """Create a bridge shell with mocked router writes."""
+
+    bridge = ARBridge.__new__(ARBridge)
+    bridge._api = Mock()
+    bridge.api.async_set_state = AsyncMock(side_effect=results)
+    return bridge
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "rule_type"),
+    [
+        ("allow", PCRuleType.DISABLE),
+        ("block", PCRuleType.BLOCK),
+        ("remove", PCRuleType.REMOVE),
+    ],
+)
+async def test_pc_rule_maps_state_and_normalizes_mac(
+    state: str,
+    rule_type: PCRuleType,
+) -> None:
+    """Each public state should produce the matching router rule."""
+
+    bridge = _bridge(True)
+
+    assert await bridge.async_pc_rule(
+        state=state,
+        devices=[{"mac": "aa:bb:cc:dd:ee:ff", "name": "Console"}],
+    )
+
+    rule = bridge.api.async_set_state.await_args.args[0]
+    assert rule.mac == "AA:BB:CC:DD:EE:FF"
+    assert rule.name == "Console"
+    assert rule.type == rule_type
+
+
+@pytest.mark.asyncio
+async def test_pc_rule_rejects_empty_targets() -> None:
+    """An empty action must not report success."""
+
+    bridge = _bridge()
+
+    assert not await bridge.async_pc_rule(state="block", devices=[])
+    bridge.api.async_set_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pc_rule_reports_partial_router_failure() -> None:
+    """Any failed router write should fail the whole action."""
+
+    bridge = _bridge(True, False)
+
+    assert not await bridge.async_pc_rule(
+        state="block",
+        devices=[
+            {"mac": "00:11:22:33:44:55"},
+            {"mac": "AA:BB:CC:DD:EE:FF"},
+        ],
+    )
+
+
+def test_service_schema_requires_target() -> None:
+    """The action should reject calls that cannot identify a device."""
+
+    with pytest.raises(vol.MultipleInvalid, match="target is required"):
+        DEVICE_INTERNET_ACCESS_SCHEMA({"state": "block"})
+
+
+def _service_hass(router: Mock) -> tuple[Mock, dict[str, object]]:
+    """Create a Home Assistant shell and capture service handlers."""
+
+    handlers: dict[str, object] = {}
+    hass = Mock()
+    hass.data = {DOMAIN: {"router-1": {ASUSROUTER: router}}}
+    hass.services.has_service.return_value = False
+    hass.services.async_register.side_effect = (
+        lambda _domain, service, handler, **_kwargs: handlers.__setitem__(
+            service, handler
+        )
+    )
+    return hass, handlers
+
+
+def _router() -> Mock:
+    """Create a router-mode service target."""
+
+    router = Mock()
+    router.mode = ROUTER
+    router.bridge.async_pc_rule = AsyncMock(return_value=True)
+    router.update_pc_rules = AsyncMock(return_value=True)
+    return router
+
+
+@pytest.mark.asyncio
+async def test_service_routes_direct_devices_to_only_router() -> None:
+    """A direct MAC target should safely resolve the only loaded router."""
+
+    router = _router()
+    hass, handlers = _service_hass(router)
+    await async_setup_services(hass)
+    handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
+    call = Mock(
+        data={
+            "devices": [{"mac": "AA:BB:CC:DD:EE:FF", "name": "Console"}],
+            "state": "block",
+        }
+    )
+
+    with patch(
+        "custom_components.asusrouter.services._get_entity_ids",
+        return_value=[],
+    ):
+        await handler(call)
+
+    router.bridge.async_pc_rule.assert_awaited_once_with(
+        state="block",
+        devices=[{"mac": "AA:BB:CC:DD:EE:FF", "name": "Console"}],
+    )
+    router.update_pc_rules.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_service_routes_entity_target_to_own_router() -> None:
+    """The GUI entity target should select its owning router."""
+
+    router = _router()
+    hass, handlers = _service_hass(router)
+    await async_setup_services(hass)
+    handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
+    device = {"mac": "AA:BB:CC:DD:EE:FF", "name": "Console"}
+    call = Mock(
+        data={
+            "entity_id": ["device_tracker.console"],
+            "state": "allow",
+        }
+    )
+
+    with (
+        patch(
+            "custom_components.asusrouter.services._get_entity_ids",
+            return_value=["device_tracker.console"],
+        ),
+        patch(
+            "custom_components.asusrouter.services."
+            "_internet_access_entity_data",
+            return_value=(router, device),
+        ),
+    ):
+        await handler(call)
+
+    router.bridge.async_pc_rule.assert_awaited_once_with(
+        state="allow",
+        devices=[device],
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_devices_require_router_for_multiple_entries() -> None:
+    """Direct MAC targets must not be sent through an arbitrary router."""
+
+    router = _router()
+    second_router = _router()
+    hass, handlers = _service_hass(router)
+    hass.data[DOMAIN]["router-2"] = {ASUSROUTER: second_router}
+    await async_setup_services(hass)
+    handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
+    call = Mock(
+        data={
+            "devices": [{"mac": "AA:BB:CC:DD:EE:FF"}],
+            "state": "block",
+        }
+    )
+
+    with (
+        patch(
+            "custom_components.asusrouter.services._get_entity_ids",
+            return_value=[],
+        ),
+        pytest.raises(ServiceValidationError, match="config_entry_id"),
+    ):
+        await handler(call)
+
+    router.bridge.async_pc_rule.assert_not_awaited()
+    second_router.bridge.async_pc_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remove_reloads_parental_control_switches() -> None:
+    """Removing a rule should reload switch entities after confirmation."""
+
+    router = _router()
+    hass, handlers = _service_hass(router)
+    await async_setup_services(hass)
+    handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
+    call = Mock(
+        data={
+            "config_entry_id": "router-1",
+            "devices": [{"mac": "AA:BB:CC:DD:EE:FF"}],
+            "state": "remove",
+        }
+    )
+
+    with (
+        patch(
+            "custom_components.asusrouter.services._get_entity_ids",
+            return_value=[],
+        ),
+        patch(
+            "custom_components.asusrouter.services."
+            "_reload_parental_control_switches",
+            new_callable=AsyncMock,
+        ) as reload_switches,
+    ):
+        await handler(call)
+
+    reload_switches.assert_awaited_once_with(router)
+
+
+@pytest.mark.asyncio
+async def test_service_surfaces_unconfirmed_router_write() -> None:
+    """A failed router write must become a visible Home Assistant error."""
+
+    router = _router()
+    router.bridge.async_pc_rule.return_value = False
+    hass, handlers = _service_hass(router)
+    await async_setup_services(hass)
+    handler = handlers[SERVICE_DEVICE_INTERNET_ACCESS]
+    call = Mock(
+        data={
+            "config_entry_id": "router-1",
+            "devices": [{"mac": "AA:BB:CC:DD:EE:FF"}],
+            "state": "block",
+        }
+    )
+
+    with (
+        patch(
+            "custom_components.asusrouter.services._get_entity_ids",
+            return_value=[],
+        ),
+        pytest.raises(HomeAssistantError, match="did not accept"),
+    ):
+        await handler(call)

--- a/tests/test_static_dhcp.py
+++ b/tests/test_static_dhcp.py
@@ -1,0 +1,251 @@
+"""Tests for static DHCP helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import pytest
+
+from custom_components.asusrouter.button import ClientStaticDHCPReserveButton
+from custom_components.asusrouter.const import DNS, IP, LIST, MAC, ROUTER
+from custom_components.asusrouter.router import ARDevice
+from custom_components.asusrouter.services import _get_entity_ids
+
+
+@dataclass
+class Lease:
+    """Static DHCP lease fixture."""
+
+    mac: str
+    ip: str
+    dns: str = ""
+    hostname: str = ""
+
+
+def _router() -> ARDevice:
+    """Create a static-DHCP-capable router shell."""
+
+    router = ARDevice.__new__(ARDevice)
+    router.hass = Mock()
+    router.bridge = Mock()
+    router._mac = "AA:AA:AA:AA:AA:AA"
+    router._mode = ROUTER
+    router._static_dhcp_lock = asyncio.Lock()
+    router._static_dhcp_leases = []
+    router._sensor_coordinator = {}
+    return router
+
+
+@pytest.mark.asyncio
+async def test_reserve_current_ip_rejects_existing_different_ip() -> None:
+    """Reserve current IP should not move an existing reservation."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        return_value=[Lease("00:11:22:33:44:55", "192.168.50.20")]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock()
+
+    with (
+        patch("custom_components.asusrouter.router.async_dispatcher_send"),
+        pytest.raises(ServiceValidationError),
+    ):
+        await router.async_reserve_current_ip(
+            "00:11:22:33:44:55",
+            "192.168.50.21",
+        )
+
+    router.bridge.async_set_static_dhcp_lease.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_static_dhcp_lease_rejects_duplicate_ip() -> None:
+    """Manual set should reject IPs already reserved for another MAC."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        return_value=[Lease("00:11:22:33:44:55", "192.168.50.20")]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock()
+
+    with (
+        patch("custom_components.asusrouter.router.async_dispatcher_send"),
+        pytest.raises(ServiceValidationError),
+    ):
+        await router.async_set_static_dhcp_lease(
+            "AA:BB:CC:DD:EE:FF",
+            "192.168.50.20",
+        )
+
+    router.bridge.async_set_static_dhcp_lease.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_static_dhcp_lease_verifies_after_write() -> None:
+    """Manual set reads leases again and caches verified data."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        side_effect=[
+            [],
+            [Lease("00:11:22:33:44:55", "192.168.50.20", hostname="Printer")],
+        ]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock(return_value=True)
+
+    with patch("custom_components.asusrouter.router.async_dispatcher_send"):
+        result = await router.async_set_static_dhcp_lease(
+            "00:11:22:33:44:55",
+            "192.168.50.20",
+            hostname="Printer",
+        )
+
+    assert result[MAC] == "00:11:22:33:44:55"
+    assert result[IP] == "192.168.50.20"
+    assert router.static_dhcp_leases == [
+        {
+            MAC: "00:11:22:33:44:55",
+            IP: "192.168.50.20",
+            "dns": "",
+            "hostname": "Printer",
+        }
+    ]
+    router.bridge.async_get_static_dhcp_leases.assert_awaited()
+    router.bridge.async_set_static_dhcp_lease.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_static_dhcp_lease_rejects_field_mismatch() -> None:
+    """Manual set fails if optional fields do not match after apply."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        side_effect=[
+            [],
+            [Lease("00:11:22:33:44:55", "192.168.50.20", hostname="Printer")],
+        ]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.asusrouter.router.async_dispatcher_send"),
+        pytest.raises(HomeAssistantError, match="did not match"),
+    ):
+        await router.async_set_static_dhcp_lease(
+            "00:11:22:33:44:55",
+            "192.168.50.20",
+            dns="1.1.1.1",
+            hostname="Printer",
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_static_dhcp_lease_raises_when_verify_fails() -> None:
+    """Manual set fails if the applied lease does not appear."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        side_effect=[[], []]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.asusrouter.router.async_dispatcher_send"),
+        pytest.raises(HomeAssistantError),
+    ):
+        await router.async_set_static_dhcp_lease(
+            "00:11:22:33:44:55",
+            "192.168.50.20",
+        )
+
+
+@pytest.mark.asyncio
+async def test_reserve_current_ip_same_lease_is_noop() -> None:
+    """Reserve current IP should no-op when the reservation already matches."""
+
+    router = _router()
+    router.bridge.async_get_static_dhcp_leases = AsyncMock(
+        return_value=[Lease("00:11:22:33:44:55", "192.168.50.20")]
+    )
+    router.bridge.async_set_static_dhcp_lease = AsyncMock()
+
+    with patch("custom_components.asusrouter.router.async_dispatcher_send"):
+        result = await router.async_reserve_current_ip(
+            "00:11:22:33:44:55",
+            "192.168.50.20",
+        )
+
+    assert result[MAC] == "00:11:22:33:44:55"
+    assert result[IP] == "192.168.50.20"
+    assert router._static_dhcp_payload(router.static_dhcp_leases)[LIST] == [
+        result
+    ]
+    router.bridge.async_set_static_dhcp_lease.assert_not_awaited()
+
+
+def test_reserve_current_ip_button_unavailable_for_duplicate_ip() -> None:
+    """Reserve button is unavailable when another MAC owns the current IP."""
+
+    router = _router()
+    router._static_dhcp_leases = [
+        {
+            MAC: "00:11:22:33:44:55",
+            IP: "192.168.50.20",
+            DNS: "",
+            "hostname": "",
+        }
+    ]
+    client = Mock()
+    client.mac_address = "AA:BB:CC:DD:EE:FF"
+    client.ip_address = "192.168.50.20"
+    client.name = "Client"
+
+    button = ClientStaticDHCPReserveButton(router, client)
+
+    assert button.available is False
+
+
+def test_get_entity_ids_filters_indirect_non_trackers() -> None:
+    """Device targets should not expand to unrelated sensors or buttons."""
+
+    selected = Mock(
+        referenced={"device_tracker.explicit"},
+        indirectly_referenced={
+            "button.reserve_ip",
+            "device_tracker.indirect",
+            "sensor.reservation_count",
+        },
+    )
+    entries = {
+        "button.reserve_ip": Mock(domain="button", platform="asusrouter"),
+        "device_tracker.indirect": Mock(
+            domain="device_tracker", platform="asusrouter"
+        ),
+        "sensor.reservation_count": Mock(
+            domain="sensor", platform="asusrouter"
+        ),
+    }
+    registry = Mock()
+    registry.async_get.side_effect = entries.get
+    call = Mock(data={"device_id": ["client-device"]})
+
+    with (
+        patch(
+            "custom_components.asusrouter.services."
+            "target_helpers.async_extract_referenced_entity_ids",
+            return_value=selected,
+        ),
+        patch(
+            "custom_components.asusrouter.services.er.async_get",
+            return_value=registry,
+        ),
+    ):
+        result = _get_entity_ids(Mock(), call)
+
+    assert result == [
+        "device_tracker.explicit",
+        "device_tracker.indirect",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -287,16 +287,12 @@ wheels = [
 
 [[package]]
 name = "asusrouter"
-version = "1.21.3"
-source = { registry = "https://pypi.org/simple" }
+version = "2.0.0.dev0"
+source = { git = "https://github.com/jgassens/asusrouter.git?rev=0d471818f60c588b78625bed50b45c7162be5e3a#0d471818f60c588b78625bed50b45c7162be5e3a" }
 dependencies = [
     { name = "aiohttp" },
     { name = "urllib3" },
     { name = "xmltodict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/f6/008706e00edb15697f3ac810f991d8791eeea21bd51deab4b41dc735326f/asusrouter-1.21.3.tar.gz", hash = "sha256:584063b48f2e2da2b0bb1f6bcf61abf4d77aa3450a8895ad64223babe6b21140", size = 130245, upload-time = "2025-12-09T20:15:05.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/50/64f14c7baa4b72bc8a01889a12d44f32a759f730ed460b48b6375dae5efa/asusrouter-1.21.3-py3-none-any.whl", hash = "sha256:d08f302e64e9585a2c14ba1f7df06b730d8bd99a59663a0f36a16f5743f9d5f0", size = 132090, upload-time = "2025-12-09T20:15:03.827Z" },
 ]
 
 [[package]]
@@ -960,7 +956,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asusrouter", specifier = "==1.21.3" },
+    { name = "asusrouter", git = "https://github.com/jgassens/asusrouter.git?rev=0d471818f60c588b78625bed50b45c7162be5e3a" },
     { name = "homeassistant", specifier = "==2026.7.4" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "ha-asusrouter"
-version = "1.0.0+jgassens.1"
+version = "1.0.0+jgassens.2"
 source = { virtual = "." }
 dependencies = [
     { name = "asusrouter" },

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "ha-asusrouter"
-version = "1.0.0.dev0"
+version = "1.0.0-jgassens.1"
 source = { virtual = "." }
 dependencies = [
     { name = "asusrouter" },

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "ha-asusrouter"
-version = "1.0.0-jgassens.1"
+version = "1.0.0+jgassens.1"
 source = { virtual = "." }
 dependencies = [
     { name = "asusrouter" },


### PR DESCRIPTION
## Summary

Wires static DHCP reservation support into the Home Assistant ASUS Router integration.

This adds HA actions and entity behavior for:

- refreshing static DHCP leases
- setting a static DHCP lease
- removing a static DHCP lease
- reserving a tracked client's current IP
- exposing reservation state in device-related entities
- disabling the reserve action when the target IP is already reserved by another MAC

## Why

Fixed IP reservations are a common router workflow, but today users need to leave Home Assistant and use the ASUS web UI or SSH. This PR keeps the workflow inside HA while using the router's existing HTTP(S) API path through the core `asusrouter` library.

## Dependency

Depends on the companion library PR:

- https://github.com/Vaskivskyi/asusrouter/pull/861

The integration manifest is kept on a versioned `asusrouter` requirement for upstream packaging. Local live testing used the exact companion library commit from the fork so the runtime smoke test exercised the new code path end to end.

## Compatibility

The implementation uses the companion library's ASUSWRT-compatible static DHCP API, based on:

- `dhcp_staticlist`
- `dhcp_static_x`
- `restart_dnsmasq`

That means the HA integration does not require router SSH access and is expected to work on stock ASUS firmware as well as Merlin builds, subject to the same model/firmware coverage as the underlying `asusrouter` library.

## Validation

- `uv run --group test pytest`
  - `15 passed`
- Targeted Ruff checks passed for the changed integration files and tests.
- Live Home Assistant + ASUS router smoke validation:
  - custom integration copied into HA and loaded after Core restart
  - service registry exposed `refresh_static_dhcp_leases`, `remove_static_dhcp_lease`, `reserve_current_ip`, and `set_static_dhcp_lease`
  - `sensor.master_bedroom_zenwifi_ax_static_dhcp_leases` reported 4 leases
  - `reserve_current_ip` for an already-selected tracked client succeeded idempotently
  - post-action lease count remained 4 and the selected reservation remained present
  - bounded log scan found no ASUS Router/static DHCP errors or tracebacks
