### PR TITLE
fix: update ScannerEntity import and fix is_connected returning None

### DIFF
--- a/custom_components/asusrouter/device_tracker.py
+++ b/custom_components/asusrouter/device_tracker.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -131,10 +130,10 @@ class ARDeviceEntity(ScannerEntity):
         return SourceType.ROUTER
 
     @property
-    def is_connected(self) -> bool | None:
+    def is_connected(self) -> bool:
         """Device status."""
 
-        return self._client.state
+        return self._client.state or False
 
     @property
     def ip_address(self) -> str | None:


### PR DESCRIPTION
## Problem

After upgrading to HA Core 2026.6+, device_trackers show `unknown` instead of `not_home` when devices are disconnected and HA is restarted.

Additionally, the integration logs a deprecation warning:
```
The deprecated alias ScannerEntity was used from asusrouter. It will be removed in HA Core 2027.6. Use homeassistant.components.device_tracker.ScannerEntity instead
```

## Root Cause

1. **Deprecated import path** - ScannerEntity was imported from `homeassistant.components.device_tracker.config_entry` which is now deprecated.

2. **is_connected returning None** - When a device is not connected to the router, the ARClient.state is `ConnectionState.UNKNOWN`, which `convert_to_ha_state_bool()` converts to `None`. The ScannerEntity interprets `is_connected = None` as `unknown` state instead of `not_home`.

## Fix

1. Updated import to use `homeassistant.components.device_tracker` (non-deprecated path)
2. Changed `is_connected` to return `False` instead of `None` when state is unknown, so devices correctly show as `not_home`

## Testing

Verified on HA Core 2026.7.4 with AsusWRT-Merlin 3004.388.11 on RT-AX88U. Device_trackers now correctly show `not_home` after restart when devices are disconnected.
